### PR TITLE
Merge standalone-release: Nuitka build/smoke automation, RHEL8 install flow, and source-projection mapping path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ docs/uml/pipeline/diagnostic_layer/diagnostic_layer_requirements.md
 examples/sources
 examples/configs/*.yml
 !examples/configs/config_example.yml
-dictionaries/
+/dictionaries/
 environment/
 scripts/utils/
 var/
 docs/*.md
-datasets/
+/datasets/

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ examples/configs/*.yml
 !examples/configs/config_example.yml
 dictionaries/
 environment/
-scripts/
+scripts/utils/
 var/
 docs/*.md
 datasets/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PYTHON ?= ./.venv/bin/python
+
+.PHONY: clean test check-standalone-prereqs build-standalone smoke-standalone package-artifacts
+
+clean:
+	rm -rf build/nuitka/standalone build/artifacts
+
+test:
+	$(PYTHON) -m pytest -q
+
+check-standalone-prereqs:
+	command -v patchelf >/dev/null
+	$(PYTHON) -m nuitka --version >/dev/null
+
+build-standalone:
+	$(MAKE) check-standalone-prereqs
+	bash scripts/build_nuitka_standalone.sh
+
+smoke-standalone:
+	bash scripts/smoke_nuitka_standalone.sh
+
+package-artifacts:
+	mkdir -p build/artifacts
+	tar -C build/nuitka/standalone -czf build/artifacts/nexus-linux-x86_64.tar.gz nexus.dist

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= ./.venv/bin/python
 
-.PHONY: clean test check-standalone-prereqs build-standalone smoke-standalone package-artifacts
+.PHONY: clean test check-standalone-prereqs build-standalone smoke-standalone package-artifacts release-standalone
 
 clean:
 	rm -rf build/nuitka/standalone build/artifacts
@@ -22,3 +22,6 @@ smoke-standalone:
 package-artifacts:
 	mkdir -p build/artifacts
 	tar -C build/nuitka/standalone -czf build/artifacts/nexus-linux-x86_64.tar.gz nexus.dist
+
+release-standalone: package-artifacts
+	sha256sum build/artifacts/nexus-linux-x86_64.tar.gz > build/artifacts/nexus-linux-x86_64.tar.gz.sha256

--- a/connector/config/projections.py
+++ b/connector/config/projections.py
@@ -31,9 +31,10 @@
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
-from connector.common.runtime_paths import RuntimePathOverrides
+from connector.common.runtime_paths import RuntimePathOverrides, detect_runtime_paths
 from connector.config.models import AppConfig
 from connector.domain.secrets.policy.rollout_metrics import VaultRolloutThresholds
 from connector.domain.secrets.policy.rollout_policy import VaultRolloutPolicySettings
@@ -41,6 +42,13 @@ from connector.domain.transform.matcher.match_deps import MatchBatchSettings
 from connector.domain.transform.resolver.resolve_deps import ResolverSettings
 from connector.infra.sqlite.config import SqliteDbConfig
 from connector.usecases.operations.vault_management_settings import VaultManagementSettings
+
+
+@dataclass(frozen=True)
+class OperationalPaths:
+    cache_dir: str
+    log_dir: str
+    report_dir: str
 
 
 def to_resolver_settings(config: AppConfig) -> ResolverSettings:
@@ -189,6 +197,37 @@ def to_vault_management_settings(config: AppConfig) -> VaultManagementSettings:
     )
 
 
+def to_dataset_registry_path(config: AppConfig) -> str | None:
+    """Resolve explicit dataset registry override against runtime root.
+
+    The override remains optional. When provided as a relative path in config,
+    it is interpreted relative to `runtime.runtime_root` instead of the process
+    working directory.
+    """
+    registry_path = config.dataset.registry_path
+    if registry_path is None:
+        return None
+
+    runtime_root = Path(config.runtime.runtime_root).expanduser()
+    if not runtime_root.is_absolute():
+        runtime_root = (Path.cwd() / runtime_root).resolve()
+
+    registry_path_obj = Path(registry_path).expanduser()
+    if registry_path_obj.is_absolute():
+        return str(registry_path_obj.resolve())
+    return str((runtime_root / registry_path_obj).resolve())
+
+
+def to_operational_paths(config: AppConfig) -> OperationalPaths:
+    """Resolve cache/log/report directories against runtime root."""
+    runtime_paths = detect_runtime_paths(overrides=to_runtime_path_overrides(config))
+    return OperationalPaths(
+        cache_dir=str(runtime_paths.cache_root),
+        log_dir=str(runtime_paths.logs_root),
+        report_dir=str(runtime_paths.reports_root),
+    )
+
+
 def to_runtime_path_overrides(config: AppConfig) -> RuntimePathOverrides:
     """AppConfig.runtime/paths → runtime resolver overrides."""
     runtime = config.runtime
@@ -217,5 +256,7 @@ __all__ = [
     "to_cache_db_config",
     "to_identity_db_config",
     "to_vault_management_settings",
+    "to_dataset_registry_path",
+    "to_operational_paths",
     "to_runtime_path_overrides",
 ]

--- a/connector/config/projections.py
+++ b/connector/config/projections.py
@@ -31,6 +31,8 @@
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 from connector.common.runtime_paths import RuntimePathOverrides
 from connector.config.models import AppConfig
 from connector.domain.secrets.policy.rollout_metrics import VaultRolloutThresholds
@@ -163,11 +165,25 @@ def to_identity_db_config(config: AppConfig) -> SqliteDbConfig:
 
 
 def to_vault_management_settings(config: AppConfig) -> VaultManagementSettings:
-    """AppConfig.vault_management → typed settings для operational vault usecases."""
+    """AppConfig.vault_management → typed settings для operational vault usecases.
+
+    Relative `admin_password_hash_file` is resolved against the active runtime root
+    so manual vault-management commands do not depend on the current working directory.
+    """
     vm = config.vault_management
+    admin_password_hash_file = vm.admin_password_hash_file
+    if admin_password_hash_file is not None:
+        runtime_root = Path(config.runtime.runtime_root).expanduser()
+        if not runtime_root.is_absolute():
+            runtime_root = (Path.cwd() / runtime_root).resolve()
+        hash_file_path = Path(admin_password_hash_file).expanduser()
+        if hash_file_path.is_absolute():
+            admin_password_hash_file = str(hash_file_path.resolve())
+        else:
+            admin_password_hash_file = str((runtime_root / hash_file_path).resolve())
     return VaultManagementSettings(
         require_admin_password_for_manual_ops=vm.require_admin_password_for_manual_ops,
-        admin_password_hash_file=vm.admin_password_hash_file,
+        admin_password_hash_file=admin_password_hash_file,
         admin_password_hash_name=vm.admin_password_hash_name,
         admin_password_env_var=vm.admin_password_env_var,
     )

--- a/connector/datasets/__init__.py
+++ b/connector/datasets/__init__.py
@@ -1,0 +1,3 @@
+from connector.datasets.apply_adapter import OperationApplyAdapter
+
+__all__ = ["OperationApplyAdapter"]

--- a/connector/datasets/apply_adapter.py
+++ b/connector/datasets/apply_adapter.py
@@ -1,0 +1,130 @@
+"""
+Назначение:
+    Универсальная реализация `ApplyAdapterProtocol` для operation-alias режима.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from connector.domain.diagnostics.exceptions import MissingRequiredSecretError
+from connector.domain.planning.plan_models import PlanItem
+from connector.domain.ports.secrets.provider import SecretProviderProtocol
+from connector.domain.ports.target.apply import ApplyAdapterProtocol
+from connector.domain.ports.target.execution import RequestSpec
+from connector.domain.secrets.errors import (
+    SecretDecryptionError,
+    SecretIntegrityError,
+    SecretNotFoundError,
+    SecretReadError,
+)
+
+PayloadBuilder = Callable[[dict[str, Any]], dict[str, Any]]
+ParamsBuilder = Callable[[PlanItem], dict[str, Any] | None]
+
+
+@dataclass
+class OperationApplyAdapter(ApplyAdapterProtocol):
+    """
+    Универсальный адаптер apply для operation-alias режима.
+
+    Назначение:
+        - гидрировать секреты из SecretProvider по `item.secret_fields`;
+        - собрать payload через переданный payload_builder;
+        - собрать параметры операции через params_builder;
+        - отдать готовый alias-intent `RequestSpec`.
+    """
+
+    operation_alias: str
+    payload_builder: PayloadBuilder
+    dataset: str
+    params_builder: ParamsBuilder | None = None
+    secrets: SecretProviderProtocol | None = field(default=None)
+
+    def to_request(self, item: PlanItem) -> RequestSpec:
+        payload_source = self._hydrate_payload_source(item)
+        payload = self.payload_builder(payload_source)
+        params = self.params_builder(item) if self.params_builder else None
+        return RequestSpec.operation(
+            alias=self.operation_alias,
+            params=params,
+            payload=payload,
+        )
+
+    def _hydrate_payload_source(self, item: PlanItem) -> dict[str, Any]:
+        """Purpose:
+            Дополнить payload обязательными секретами только для `item.secret_fields`.
+
+        Contract:
+            - если поле уже заполнено в `desired_state`, повторный read не выполняется;
+            - lookup miss или `SecretNotFoundError` маппится в `SECRET_REQUIRED`;
+            - read/decrypt/integrity сбои маппятся в соответствующие `SECRET_*` коды.
+        """
+        payload_source = dict(item.desired_state)
+        for secret_field in item.secret_fields:
+            if payload_source.get(secret_field):
+                continue
+            try:
+                secret = (
+                    self.secrets.get_secret(
+                        dataset=self.dataset,
+                        field=secret_field,
+                        row_id=item.row_id,
+                        line_no=item.line_no,
+                        source_ref=item.source_ref,
+                        target_id=item.target_id,
+                    )
+                    if self.secrets
+                    else None
+                )
+            except SecretNotFoundError as exc:
+                raise MissingRequiredSecretError(
+                    dataset=self.dataset,
+                    field=secret_field,
+                    row_id=item.row_id,
+                    line_no=item.line_no,
+                    target_id=item.target_id,
+                    diag_code="SECRET_REQUIRED",
+                ) from exc
+            except SecretReadError as exc:
+                raise MissingRequiredSecretError(
+                    dataset=self.dataset,
+                    field=secret_field,
+                    row_id=item.row_id,
+                    line_no=item.line_no,
+                    target_id=item.target_id,
+                    diag_code="SECRET_READ_ERROR",
+                ) from exc
+            except SecretDecryptionError as exc:
+                raise MissingRequiredSecretError(
+                    dataset=self.dataset,
+                    field=secret_field,
+                    row_id=item.row_id,
+                    line_no=item.line_no,
+                    target_id=item.target_id,
+                    diag_code="SECRET_DECRYPTION_ERROR",
+                ) from exc
+            except SecretIntegrityError as exc:
+                raise MissingRequiredSecretError(
+                    dataset=self.dataset,
+                    field=secret_field,
+                    row_id=item.row_id,
+                    line_no=item.line_no,
+                    target_id=item.target_id,
+                    diag_code="SECRET_INTEGRITY_ERROR",
+                ) from exc
+            if not secret:
+                raise MissingRequiredSecretError(
+                    dataset=self.dataset,
+                    field=secret_field,
+                    row_id=item.row_id,
+                    line_no=item.line_no,
+                    target_id=item.target_id,
+                    diag_code="SECRET_REQUIRED",
+                )
+            payload_source[secret_field] = secret
+        return payload_source
+
+
+__all__ = ["OperationApplyAdapter"]

--- a/connector/datasets/cache_sync.py
+++ b/connector/datasets/cache_sync.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol, Any
+
+
+class CacheSyncAdapterProtocol(Protocol):
+    """
+    Назначение/ответственность:
+        Стратегия синхронизации кэша для конкретного датасета.
+    Взаимодействия:
+        Используется CacheRefreshUseCase совместно с TargetPagedReader.
+    """
+
+    dataset: str
+    list_operation_alias: str
+    report_entity: str
+
+    def get_item_key(self, raw_item: dict[str, Any]) -> str: ...
+    def is_deleted(self, raw_item: dict[str, Any]) -> bool: ...
+    def map_target_to_cache(self, raw_item: dict[str, Any]) -> dict[str, Any]: ...

--- a/connector/datasets/registry.py
+++ b/connector/datasets/registry.py
@@ -1,0 +1,308 @@
+"""Назначение:
+    Реестр DatasetSpec factories с auto-discovery из `datasets/registry.yml`.
+
+Граница ответственности:
+    - Owns: выбор factory по имени датасета, auto-discovery и eager registry validation.
+    - Owns: strict validation policy для custom `spec_class` factories.
+    - Does NOT: детали eager YAML loading и runtime accessor behavior самих DatasetSpec.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from functools import partial
+from typing import Any, Callable
+
+from connector.datasets.spec import DatasetSpec
+from connector.domain.dsl.loader import load_registry
+from connector.domain.ports.secrets.provider import SecretProviderProtocol
+
+_REQUIRED_DATASET_SPEC_MEMBERS = (
+    "build_spec_for",
+    "build_record_source",
+    "get_report_adapter",
+    "get_apply_adapter",
+    "get_diagnostic_catalog",
+)
+
+
+def _make_yaml_spec(
+    dataset_name: str,
+    secrets: SecretProviderProtocol | None = None,
+) -> DatasetSpec:
+    from connector.datasets.yaml_spec import YamlDatasetSpec
+    from connector.datasets.yaml_spec_loader import load_yaml_dataset_artifacts
+
+    artifacts = load_yaml_dataset_artifacts(dataset_name)
+    return YamlDatasetSpec(artifacts, secrets)
+
+
+def _format_spec_class_error(dataset_name: str, spec_class_ref: str, reason: str) -> str:
+    return (
+        f"Invalid spec_class for dataset '{dataset_name}' ({spec_class_ref!r}): {reason}"
+    )
+
+
+def _import_spec_symbol(dataset_name: str, spec_class_ref: str) -> Any:
+    """Назначение:
+        Импортировать symbol для custom dataset factory по строковой ссылке.
+
+    Контракт:
+        Формат ref — `module.path:factory_function` или `module.path:ClassName`.
+    """
+    module_path, _, attr_name = spec_class_ref.rpartition(":")
+    if not module_path or not attr_name:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "expected format 'module.path:factory_or_class'",
+            )
+        )
+    module = importlib.import_module(module_path)
+    return getattr(module, attr_name)
+
+
+def _assert_custom_factory_signature(
+    dataset_name: str,
+    spec_class_ref: str,
+    symbol: Any,
+) -> None:
+    """Назначение:
+        Проверить строгий factory contract для `spec_class`.
+
+    Контракт:
+        - symbol callable;
+        - принимает keyword `secrets`;
+        - `secrets` optional (имеет default);
+        - positional-only / required `secrets` не поддерживаются.
+    """
+    if not callable(symbol):
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "imported symbol must be callable",
+            )
+        )
+
+    try:
+        signature = inspect.signature(symbol)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "callable signature is not introspectable",
+            )
+        ) from exc
+
+    parameter = signature.parameters.get("secrets")
+    if parameter is None:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "factory must declare optional keyword parameter 'secrets'",
+            )
+        )
+
+    if parameter.kind not in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    ):
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "parameter 'secrets' must be keyword-compatible",
+            )
+        )
+
+    if parameter.default is inspect.Parameter.empty:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "parameter 'secrets' must be optional and default to None or another value",
+            )
+        )
+
+
+def _assert_dataset_spec_instance(
+    dataset_name: str,
+    spec_class_ref: str,
+    instance: Any,
+) -> None:
+    """Назначение:
+        Валидировать DatasetSpec instance на уровне registry policy.
+
+    Контракт:
+        - объект обязан иметь dataset_name и обязательные DatasetSpec methods;
+        - instance.dataset_name должен совпадать с ключом датасета в registry.yml.
+    """
+    instance_dataset_name = getattr(instance, "dataset_name", None)
+    if not isinstance(instance_dataset_name, str) or not instance_dataset_name:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "factory must return DatasetSpec with non-empty 'dataset_name'",
+            )
+        )
+
+    missing_members = [
+        member_name
+        for member_name in _REQUIRED_DATASET_SPEC_MEMBERS
+        if not callable(getattr(instance, member_name, None))
+    ]
+    if missing_members:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                "factory must return DatasetSpec with methods: "
+                + ", ".join(_REQUIRED_DATASET_SPEC_MEMBERS)
+                + f"; missing: {', '.join(missing_members)}",
+            )
+        )
+
+    if instance_dataset_name != dataset_name:
+        raise ValueError(
+            _format_spec_class_error(
+                dataset_name,
+                spec_class_ref,
+                f"factory returned dataset_name={instance_dataset_name!r}, expected {dataset_name!r}",
+            )
+        )
+
+
+def _resolve_spec_factory(
+    dataset_name: str,
+    spec_class_ref: str,
+) -> Callable[..., DatasetSpec]:
+    """Назначение:
+        Нормализовать `spec_class` в factory с единым контрактом `factory(*, secrets=None)`.
+    """
+    symbol = _import_spec_symbol(dataset_name, spec_class_ref)
+    _assert_custom_factory_signature(dataset_name, spec_class_ref, symbol)
+
+    def _factory(*, secrets: SecretProviderProtocol | None = None) -> DatasetSpec:
+        try:
+            instance = symbol(secrets=secrets)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(
+                _format_spec_class_error(
+                    dataset_name,
+                    spec_class_ref,
+                    "factory call failed for keyword 'secrets': "
+                    f"{type(exc).__name__}: {exc}",
+                )
+            ) from exc
+
+        _assert_dataset_spec_instance(dataset_name, spec_class_ref, instance)
+        return instance
+
+    return _factory
+
+
+def _build_registry() -> dict[str, Callable[..., DatasetSpec]]:
+    """
+    Назначение:
+        Auto-discovery датасетов из registry.yml.
+    """
+    registry_data = load_registry()
+    datasets = registry_data.get("datasets") or {}
+    result: dict[str, Callable[..., DatasetSpec]] = {}
+    for name, entry in datasets.items():
+        spec_class_ref = entry.get("spec_class") if isinstance(entry, dict) else None
+        if spec_class_ref:
+            result[name] = _resolve_spec_factory(name, spec_class_ref)
+        else:
+            result[name] = partial(_make_yaml_spec, name)
+    return result
+
+
+_registry: dict[str, Callable[..., DatasetSpec]] | None = None
+
+
+def _get_registry() -> dict[str, Callable[..., DatasetSpec]]:
+    global _registry  # noqa: PLW0603
+    if _registry is None:
+        _registry = _build_registry()
+    return _registry
+
+
+def get_spec(dataset: str, secrets: SecretProviderProtocol | None = None) -> DatasetSpec:
+    """
+    Возвращает DatasetSpec по имени или ValueError, если не зарегистрирован.
+    """
+    registry = _get_registry()
+    try:
+        factory = registry[dataset]
+        return factory(secrets=secrets)
+    except KeyError as exc:
+        raise ValueError(f"Unsupported dataset: {dataset}") from exc
+
+
+def list_specs(secrets: SecretProviderProtocol | None = None) -> list[DatasetSpec]:
+    registry = _get_registry()
+    return [factory(secrets=secrets) for factory in registry.values()]
+
+
+def validate_registry() -> None:
+    """
+    Назначение:
+        Eagerly validate all dataset registrations before runtime command path.
+
+    Контракт:
+        - для YAML-driven datasets загружает полный snapshot артефактов;
+        - для `spec_class` eagerly вызывает strict factory с `secrets=None`;
+        - не кеширует preloaded spec объекты глобально.
+    """
+    from connector.datasets.yaml_spec_loader import load_yaml_dataset_artifacts
+
+    registry_data = load_registry()
+    datasets = registry_data.get("datasets") or {}
+    for name, entry in datasets.items():
+        spec_class_ref = entry.get("spec_class") if isinstance(entry, dict) else None
+        if spec_class_ref:
+            _resolve_spec_factory(name, spec_class_ref)(secrets=None)
+            continue
+        load_yaml_dataset_artifacts(name)
+
+
+def resolve_dataset_name(dataset: str | None, default: str) -> str:
+    """
+    Назначение:
+        Определить имя датасета с учётом значения по умолчанию.
+    """
+    return dataset if dataset is not None else default
+
+
+def build_identity_index_plan(
+    secrets: SecretProviderProtocol | None = None,
+) -> tuple[dict[str, set[str]], dict[str, str]]:
+    """
+    Возвращает:
+        keys_by_dataset: какие ключи индексировать для identity_index (dataset -> set[key_name]).
+        id_field_by_dataset: поле resolved_id для датасета (dataset -> field_name).
+    """
+    keys_by_dataset: dict[str, set[str]] = {}
+    id_field_by_dataset: dict[str, str] = {}
+    for spec in list_specs(secrets=secrets):
+        resolve_spec = spec.build_spec_for("resolve")
+        for link_spec in resolve_spec.resolve.links:
+            dataset = link_spec.target_dataset
+            if dataset in id_field_by_dataset and id_field_by_dataset[dataset] != link_spec.target_id_field:
+                raise ValueError(
+                    "conflicting target_id_field for dataset "
+                    f"{dataset}: {id_field_by_dataset[dataset]} vs {link_spec.target_id_field}"
+                )
+            id_field_by_dataset.setdefault(dataset, link_spec.target_id_field)
+            keys = keys_by_dataset.setdefault(dataset, set())
+            keys.update(key_rule.name for key_rule in link_spec.resolve_keys)
+            for dedup in link_spec.dedup_rules:
+                keys.update(dedup)
+    return keys_by_dataset, id_field_by_dataset

--- a/connector/datasets/spec.py
+++ b/connector/datasets/spec.py
@@ -1,0 +1,62 @@
+"""
+Назначение:
+    Контракты dataset-плагина для transform/planning/apply сценариев.
+
+    DatasetSpec (Protocol) — narrowed: DSL configuration + adapters.
+    Phase 2 (DEC-009): typed build_*_spec() заменены на generic build_spec_for(stage_type).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+from connector.domain.diagnostics.catalog import ErrorCatalog
+from connector.domain.ports.target.apply import ApplyAdapterProtocol
+from connector.domain.transform.core.source_record import SourceRecord
+
+
+@dataclass(frozen=True)
+class ReportAdapter:
+    """
+    Назначение:
+        Набор констант/лейблов для отчётов по датасету.
+    """
+    identity_label: str
+    conflict_code: str
+    conflict_field: str
+
+
+class UnsupportedStageError(Exception):
+    """
+    Назначение:
+        Стадия не поддерживается данным датасетом.
+    """
+
+    def __init__(self, stage_type: str, *, dataset: str) -> None:
+        self.stage_type = stage_type
+        self.dataset = dataset
+        super().__init__(
+            f"Dataset '{dataset}' does not support stage type '{stage_type}'"
+        )
+
+
+class DatasetSpec(Protocol):
+    """
+    Назначение:
+        Контракт плагина датасета: DSL configuration + adapters.
+
+    Граница:
+        - build_spec_for(stage_type) — generic accessor для DSL-спецификации стадии (Phase 2, DEC-009).
+        - build_record_source() — доступ к источнику данных.
+        - get_report_adapter() / get_apply_adapter() — отчётные/apply адаптеры.
+        - get_diagnostic_catalog() — каталог ошибок.
+    """
+
+    dataset_name: str
+
+    def build_spec_for(self, stage_type: str) -> object: ...
+    def build_record_source(self) -> Iterable[SourceRecord]: ...
+    def get_report_adapter(self) -> ReportAdapter: ...
+    def get_apply_adapter(self) -> ApplyAdapterProtocol: ...
+    def get_diagnostic_catalog(self, strict: bool) -> ErrorCatalog: ...

--- a/connector/datasets/yaml_spec.py
+++ b/connector/datasets/yaml_spec.py
@@ -1,0 +1,117 @@
+"""Назначение:
+    Runtime accessor для уже загруженного YAML-driven DatasetSpec.
+
+Граница ответственности:
+    - Owns: доступ к preloaded dataset snapshot и сборку runtime adapters.
+    - Does NOT: чтение YAML-файлов, eager validation registry и выбор dataset factory.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from connector.datasets.apply_adapter import OperationApplyAdapter
+from connector.datasets.spec import ReportAdapter, UnsupportedStageError
+from connector.datasets.yaml_spec_loader import LoadedYamlDatasetArtifacts
+from connector.domain.dataset_dsl.catalog_compiler import compile_diagnostic_catalog
+from connector.domain.dataset_dsl.params_compiler import resolve_params_builder
+from connector.domain.dataset_dsl.payload_compiler import SinkDrivenPayloadBuilder
+from connector.domain.diagnostics.catalog import ErrorCatalog
+from connector.domain.ports.secrets.provider import SecretProviderProtocol
+from connector.domain.ports.target.apply import ApplyAdapterProtocol
+from connector.domain.transform.core.source_record import SourceRecord
+from connector.domain.transform_dsl import resolve_source_location
+from connector.infra.sources.csv_reader import CsvRecordSource
+
+
+class YamlDatasetSpec:
+    """Назначение:
+        Generic DatasetSpec поверх preloaded YAML snapshot.
+
+    Контракт:
+        - `build_spec_for()` не делает I/O и возвращает изолированную копию spec;
+        - `build_record_source()` использует только preloaded `SourceSpec`;
+        - `get_apply_adapter()` использует только preloaded `SinkSpec` и dataset DSL.
+    """
+
+    def __init__(
+        self,
+        artifacts: LoadedYamlDatasetArtifacts,
+        secrets: SecretProviderProtocol | None = None,
+    ) -> None:
+        self.dataset_name = artifacts.dataset_name
+        self._artifacts = artifacts
+        self._secrets = secrets
+
+    def build_spec_for(self, stage_type: str) -> object:
+        """Назначение:
+            Вернуть preloaded stage spec по ключу без повторной загрузки YAML.
+
+        Контракт:
+            - unknown stage → `UnsupportedStageError`;
+            - каждая выдача изолирована через `model_copy(deep=True)`.
+        """
+        stage_spec = self._artifacts.stage_specs.get(stage_type)
+        if stage_spec is None:
+            raise UnsupportedStageError(stage_type, dataset=self.dataset_name)
+        return stage_spec.model_copy(deep=True)
+
+    def build_record_source(self) -> Iterable[SourceRecord]:
+        """Назначение:
+            Построить record source из preloaded source spec.
+
+        Контракт:
+            - не читает source YAML повторно;
+            - path resolution выполняется runtime-safe через `source.location`.
+        """
+        source_spec = self._artifacts.source_spec
+        if source_spec.source.type != "file" or source_spec.source.format != "csv":
+            raise ValueError(
+                f"{self.dataset_name} source spec must be file/csv for current runtime"
+            )
+        source_path = resolve_source_location(source_spec)
+        csv_options = source_spec.source.csv_options()
+        return CsvRecordSource(
+            source_path,
+            source_spec.source.has_header,
+            delimiter=csv_options.delimiter,
+            encoding=csv_options.encoding,
+        )
+
+    def get_report_adapter(self) -> ReportAdapter:
+        r = self._artifacts.dataset_dsl.report
+        return ReportAdapter(
+            identity_label=r.identity_label,
+            conflict_code=r.conflict_code,
+            conflict_field=r.conflict_field,
+        )
+
+    def get_apply_adapter(self) -> ApplyAdapterProtocol:
+        """Назначение:
+            Собрать apply adapter поверх preloaded sink spec и dataset DSL.
+
+        Контракт:
+            - не читает sink YAML повторно;
+            - каждый вызов создаёт новый adapter instance.
+        """
+        sink_spec = self._artifacts.sink_spec
+        apply = self._artifacts.dataset_dsl.apply
+        payload_builder = SinkDrivenPayloadBuilder(
+            sink_spec=sink_spec,
+            defaults=dict(apply.payload.defaults),
+            conditional_fields=list(apply.payload.conditional_fields),
+        )
+        params_builder = resolve_params_builder(apply.params)
+        return OperationApplyAdapter(
+            operation_alias=apply.operation_alias,
+            payload_builder=payload_builder,
+            dataset=self.dataset_name,
+            params_builder=params_builder,
+            secrets=self._secrets,
+        )
+
+    def get_diagnostic_catalog(self, strict: bool) -> ErrorCatalog:
+        return compile_diagnostic_catalog(
+            self._artifacts.dataset_dsl.diagnostics,
+            strict=strict,
+        )

--- a/connector/datasets/yaml_spec_loader.py
+++ b/connector/datasets/yaml_spec_loader.py
@@ -1,0 +1,90 @@
+"""Назначение:
+    Eager loading snapshot для YAML-driven DatasetSpec.
+
+Граница ответственности:
+    - Owns: разовую загрузку и валидацию dataset-level/runtime DSL артефактов
+      для одного датасета.
+    - Does NOT: runtime accessor API DatasetSpec, apply/report adapters и
+      registry auto-discovery policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+from connector.domain.dataset_dsl.loader import load_dataset_dsl_spec
+from connector.domain.dataset_dsl.specs import DatasetDslSpec
+from connector.domain.dsl.specs._base import DslBaseModel
+from connector.domain.transform_dsl import (
+    load_enrich_spec_for_dataset,
+    load_mapping_spec_for_dataset,
+    load_match_spec_for_dataset,
+    load_normalize_spec_for_dataset,
+    load_resolve_spec_for_dataset,
+    load_sink_spec_for_dataset,
+    load_source_spec_for_dataset,
+)
+from connector.domain.transform_dsl.specs import SinkSpec, SourceSpec
+
+SUPPORTED_YAML_STAGE_LOADERS = {
+    "map": load_mapping_spec_for_dataset,
+    "normalize": load_normalize_spec_for_dataset,
+    "enrich": load_enrich_spec_for_dataset,
+    "match": load_match_spec_for_dataset,
+    "resolve": load_resolve_spec_for_dataset,
+    "sink": load_sink_spec_for_dataset,
+}
+
+
+@dataclass(frozen=True)
+class LoadedYamlDatasetArtifacts:
+    """Назначение:
+        Immutable snapshot уже загруженных YAML-артефактов датасета.
+
+    Контракт:
+        - содержит только валидированные DSL-модели;
+        - не выполняет lazy loading;
+        - используется как единственный источник runtime access в `YamlDatasetSpec`.
+    """
+
+    dataset_name: str
+    dataset_dsl: DatasetDslSpec
+    source_spec: SourceSpec
+    sink_spec: SinkSpec
+    stage_specs: Mapping[str, DslBaseModel]
+
+
+def load_yaml_dataset_artifacts(dataset_name: str) -> LoadedYamlDatasetArtifacts:
+    """Назначение:
+        Загрузить полный YAML snapshot датасета для runtime DatasetSpec.
+
+    Контракт:
+        - eager loads dataset-level DSL, source, sink и все поддерживаемые
+          stage specs;
+        - валидирует конфигурацию до выполнения команд;
+        - не кеширует результаты глобально.
+    """
+
+    dataset_dsl = load_dataset_dsl_spec(dataset_name)
+    source_spec = load_source_spec_for_dataset(dataset_name)
+    stage_specs = {
+        stage_type: loader(dataset_name)
+        for stage_type, loader in SUPPORTED_YAML_STAGE_LOADERS.items()
+    }
+    sink_spec = stage_specs["sink"]
+    return LoadedYamlDatasetArtifacts(
+        dataset_name=dataset_name,
+        dataset_dsl=dataset_dsl,
+        source_spec=source_spec,
+        sink_spec=sink_spec,
+        stage_specs=MappingProxyType(dict(stage_specs)),
+    )
+
+
+__all__ = [
+    "LoadedYamlDatasetArtifacts",
+    "SUPPORTED_YAML_STAGE_LOADERS",
+    "load_yaml_dataset_artifacts",
+]

--- a/connector/delivery/cli/app.py
+++ b/connector/delivery/cli/app.py
@@ -8,7 +8,7 @@ import typer
 from connector.config.config import SettingsLoadError
 from connector.config.loader import load_app_config
 from connector.config.diagnostics import translate_settings_load_error
-from connector.config.projections import to_runtime_path_overrides
+from connector.config.projections import to_dataset_registry_path, to_operational_paths, to_runtime_path_overrides
 from connector.common.run_id import generate_run_id
 from connector.delivery.cli.context import CommandPaths, CommandContext, UnboundCommandContext
 from connector.delivery.cli.requirements import Requirements
@@ -57,6 +57,7 @@ def _build_ctx(
     app_config = ctx.obj.get("app_config")
     if app_config is None:
         raise RuntimeError("App config is not initialized")
+    operational_paths = to_operational_paths(app_config)
     catalog = build_diagnostics_catalog(dataset, strict=app_config.observability.diagnostics_strict)
     extra: dict[str, Any] = {"sources": ctx.obj.get("sources")}
     if command_key:
@@ -74,7 +75,7 @@ def _build_ctx(
         strict=app_config.observability.diagnostics_strict,
         app_config=app_config,
         container=None,
-        paths=CommandPaths(report_dir=app_config.paths.report_dir, work_dir=None),
+        paths=CommandPaths(report_dir=operational_paths.report_dir, work_dir=None),
         extra=extra,
     )
 
@@ -168,14 +169,16 @@ def main(
             typer.echo(f"- [{diag.code}]{field} {diag.message}", err=True)
         raise typer.Exit(code=2) from exc
     configure_runtime_paths(to_runtime_path_overrides(loaded_app.app_config))
-    configure_registry_path(loaded_app.app_config.dataset.registry_path)
-    _ensure_dir(loaded_app.app_config.paths.log_dir)
-    _ensure_dir(loaded_app.app_config.paths.report_dir)
-    _ensure_dir(loaded_app.app_config.paths.cache_dir)
+    configure_registry_path(to_dataset_registry_path(loaded_app.app_config))
+    operational_paths = to_operational_paths(loaded_app.app_config)
+    _ensure_dir(operational_paths.log_dir)
+    _ensure_dir(operational_paths.report_dir)
+    _ensure_dir(operational_paths.cache_dir)
 
     ctx.obj = {
         "run_id": run_id,
         "app_config": loaded_app.app_config,
+        "operational_paths": operational_paths,
         "sources": sorted({v for v in loaded_app.source_trace.values() if v != "default"}),
         "settings_source_trace": loaded_app.source_trace,
         "configPath": config,

--- a/connector/delivery/cli/containers.py
+++ b/connector/delivery/cli/containers.py
@@ -35,6 +35,7 @@ from dependency_injector import containers, providers
 from connector.config.models import ApiConfig, AppConfig, DatasetConfig
 from connector.config.projections import (
     to_cache_db_config,
+    to_dataset_registry_path,
     to_identity_db_config,
     to_resolver_settings,
     to_runtime_path_overrides,
@@ -847,13 +848,13 @@ class AppContainer(containers.DeclarativeContainer):
     _cache_dir = providers.Callable(lambda s: s.paths.cache_dir, s=app_config)
     _api_settings = providers.Callable(lambda s: s.api, s=app_config)
     _dictionary_cfg = providers.Callable(lambda s: s.dictionary, s=app_config)
-    _dataset_registry_path = providers.Callable(lambda s: s.dataset.registry_path, s=app_config)
+    _dataset_registry_path = providers.Callable(to_dataset_registry_path, config=app_config)
     _dictionary_specs_root = providers.Callable(
-        lambda s: s.runtime.dictionary_specs_root,
+        lambda s: str(_runtime_paths_for(s).dictionary_specs_root),
         s=app_config,
     )
     _dictionary_data_root = providers.Callable(
-        lambda s: s.runtime.dictionary_data_root,
+        lambda s: str(_runtime_paths_for(s).dictionary_data_root),
         s=app_config,
     )
     _vault_management_settings = providers.Callable(to_vault_management_settings, config=app_config)

--- a/connector/delivery/cli/dictionaries_container.py
+++ b/connector/delivery/cli/dictionaries_container.py
@@ -48,7 +48,10 @@ from connector.infra.dictionaries.telemetry import DictionaryTelemetry
 def _normalize_optional_path(path: str | Path | None) -> Path | None:
     if path is None:
         return None
-    return Path(path).expanduser().resolve()
+    path_obj = Path(path).expanduser()
+    if path_obj.is_absolute():
+        return path_obj.resolve()
+    return (get_runtime_paths().root / path_obj).resolve()
 
 
 def _load_runtime_bundle_optional(

--- a/connector/delivery/cli/runtime/orchestrator.py
+++ b/connector/delivery/cli/runtime/orchestrator.py
@@ -24,6 +24,7 @@ from connector.common.time import get_duration_ms
 from connector.config.config import SettingsLoadError
 from connector.config.models import AppConfig
 from connector.config.diagnostics import translate_settings_load_error
+from connector.config.projections import to_operational_paths
 from connector.domain.diagnostics.command_result import CommandResult as DomainCommandResult
 from connector.domain.dsl.diagnostics import translate_dsl_load_error
 from connector.domain.dsl.issues import DslLoadError
@@ -78,7 +79,7 @@ def run_with_report(
         - Result-to-report mapping выполняется через injected mapper.
     """
     app_config = require_app_settings(ctx)
-    paths = app_config.paths
+    paths = to_operational_paths(app_config)
     observability = app_config.observability
     run_id = ctx.run_id
 
@@ -618,7 +619,7 @@ def require_api(app_config: AppConfig) -> None:
 
 
 def require_cache(app_config: AppConfig) -> None:
-    cache_dir = Path(app_config.paths.cache_dir)
+    cache_dir = Path(to_operational_paths(app_config).cache_dir)
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
     except OSError as exc:

--- a/connector/delivery/commands/import_plan.py
+++ b/connector/delivery/commands/import_plan.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import typer
 
 from connector.common.time import get_now_iso
+from connector.config.projections import to_operational_paths, to_vault_rollout_policy_settings
 from connector.delivery.cli.containers import build_dataset_spec, build_diagnostics_catalog
 from connector.delivery.cli.context import BoundCommandContext
 from connector.delivery.commands.common import (
@@ -29,7 +30,6 @@ from connector.domain.secrets.errors import (
     VaultStartupStorageReadonlyError,
     VaultStartupUninitializedReadonlyError,
 )
-from connector.config.projections import to_vault_rollout_policy_settings
 from connector.domain.secrets.policy.rollout_policy import evaluate_vault_rollout
 from connector.domain.secrets.policy.runtime_mode_policy import (
     RUNTIME_REASON_INVALID_MODE,
@@ -176,7 +176,7 @@ def handler(ctx: BoundCommandContext, opts: Options, report_sink=None) -> Comman
                 plan_items=plan_result.items,
                 summary=plan_result.summary_as_dict(),
                 meta=plan_meta,
-                report_dir=app_config.paths.report_dir,
+                report_dir=to_operational_paths(app_config).report_dir,
                 run_id=run_id,
                 generated_at=generated_at,
             )

--- a/connector/domain/dsl/ops.py
+++ b/connector/domain/dsl/ops.py
@@ -11,7 +11,7 @@ import uuid
 from functools import lru_cache
 from typing import Any, Iterable
 
-from anyascii import anyascii
+from unidecode import unidecode
 
 
 def _normalize_whitespace(value: object | None, *, empty_to_none: bool = False) -> str | None:
@@ -192,7 +192,7 @@ def op_transliterate(value: Any, **_: Any) -> str | None:
         - `None -> None`
         - пустая строка сохраняется пустой строкой
         - ASCII-строка возвращается без изменений
-        - non-ASCII строка преобразуется через `anyascii`
+        - non-ASCII строка преобразуется через `unidecode`
     """
     if value is None:
         return None
@@ -201,7 +201,7 @@ def op_transliterate(value: Any, **_: Any) -> str | None:
         return ""
     if text.isascii():
         return text
-    return anyascii(text)
+    return unidecode(text)
 
 
 def op_upper(value: Any, **_: Any) -> str | None:

--- a/connector/domain/transform_dsl/loader.py
+++ b/connector/domain/transform_dsl/loader.py
@@ -222,7 +222,7 @@ def _resolve_dataset_path(registry: dict[str, Any], dataset: str, stage: str) ->
             message=f"Dataset '{dataset}' does not define '{stage}' in registry file",
             details={"dataset": dataset, "stage": stage},
         )
-    if stage == "source":
+    if stage in {"source", "mapping"}:
         return _resolve_source_projection_path(filename)
     return _resolve_dataset_stage_path(filename)
 

--- a/connector/infra/dictionaries/__init__.py
+++ b/connector/infra/dictionaries/__init__.py
@@ -1,0 +1,39 @@
+"""
+Назначение:
+    Infra runtime компоненты Dictionary layer (v1 foundation).
+
+Граница ответственности:
+    - Содержит runtime compilation, CSV loading и backend реализации.
+    - Не содержит DI/container wiring (delivery слой).
+"""
+
+from connector.infra.dictionaries.dsl_runtime import (
+    CompiledDictionaryOperation,
+    CompiledDictionarySpec,
+    DictionaryDslRuntimeBundle,
+    build_dictionary_dsl_runtime,
+)
+from connector.infra.dictionaries.loader_csv import CsvDictionaryLoader
+from connector.infra.dictionaries.versioning import (
+    DictionaryVersionInfo,
+    build_content_sha256_bytes,
+    build_content_sha256_for_file,
+    build_dictionary_schema_hash,
+    build_dictionary_version_id,
+    build_dictionary_version_info,
+)
+
+__all__ = [
+    "CompiledDictionaryOperation",
+    "CompiledDictionarySpec",
+    "CsvDictionaryLoader",
+    "DictionaryDslRuntimeBundle",
+    "DictionaryVersionInfo",
+    "build_content_sha256_bytes",
+    "build_content_sha256_for_file",
+    "build_dictionary_dsl_runtime",
+    "build_dictionary_schema_hash",
+    "build_dictionary_version_id",
+    "build_dictionary_version_info",
+]
+

--- a/connector/infra/dictionaries/backends/__init__.py
+++ b/connector/infra/dictionaries/backends/__init__.py
@@ -1,0 +1,9 @@
+"""
+Назначение:
+    Backend-реализации Dictionary runtime.
+"""
+
+from connector.infra.dictionaries.backends.polars_backend import PolarsDictionaryBackend
+
+__all__ = ["PolarsDictionaryBackend"]
+

--- a/connector/infra/dictionaries/backends/polars_backend.py
+++ b/connector/infra/dictionaries/backends/polars_backend.py
@@ -1,0 +1,331 @@
+"""
+Назначение:
+    In-memory backend словарей на базе `polars` для Dictionary runtime v1.
+
+Граница ответственности:
+    - Хранит загруженные DataFrame и выполняет lookup/contains/canonicalize.
+    - Строит in-memory индекс по (возможно нормализованному) ключу.
+    - Не читает CSV и не валидирует manifest/fingerprint (это `loader_csv.py`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import polars as pl
+
+from connector.domain.dsl.issues import DslLoadError
+from connector.infra.dictionaries.dsl_runtime import CompiledDictionarySpec, DictionaryDslRuntimeBundle
+from connector.infra.dictionaries.versioning import (
+    DictionaryVersionInfo,
+    build_dictionary_version_info,
+)
+
+
+@dataclass(frozen=True)
+class _LoadedDictionaryData:
+    """
+    Назначение:
+        Runtime-состояние одного загруженного словаря (данные + индекс + version info).
+    """
+
+    compiled: CompiledDictionarySpec
+    frame: pl.DataFrame
+    rows: tuple[dict[str, Any], ...]
+    key_index: dict[str, tuple[int, ...]]
+    version_info: DictionaryVersionInfo
+
+
+class PolarsDictionaryBackend:
+    """
+    Назначение:
+        In-memory lookup backend словарей поверх `polars.DataFrame`.
+
+    Контракт:
+        - Требует `DictionaryDslRuntimeBundle` (скомпилированный DSL без IO).
+        - Данные загружаются отдельно через `CsvDictionaryLoader.load_into(self)`.
+        - Поддерживает lazy first-load через callback, если настроен orchestration-слоем.
+        - Unknown dict в non-empty runtime -> `KeyError`.
+        - Empty runtime (`items:{}`) трактуется как miss (lookup=[] / contains=False).
+    """
+
+    def __init__(
+        self,
+        *,
+        bundle: DictionaryDslRuntimeBundle,
+        lazy_loader: Callable[[str], None] | None = None,
+    ) -> None:
+        self.bundle = bundle
+        self._lazy_loader = lazy_loader
+        self._loaded: dict[str, _LoadedDictionaryData] = {}
+        self._loading_in_progress: set[str] = set()
+
+    def load_dictionary_frame(
+        self,
+        *,
+        dict_name: str,
+        frame: pl.DataFrame,
+        content_sha256: str,
+    ) -> DictionaryVersionInfo:
+        """
+        Назначение:
+            Загрузить/заменить данные словаря из готового `polars.DataFrame`.
+
+        Contract:
+            - Проверяет наличие обязательных колонок и duplicate policy.
+            - Строит key-index по нормализованному ключу.
+            - Пустой DataFrame с корректными колонками допустим.
+        """
+        compiled = self.bundle.get(dict_name)
+        self._validate_columns(compiled=compiled, frame=frame)
+
+        rows = tuple(frame.iter_rows(named=True))
+        key_index = self._build_key_index(compiled=compiled, rows=rows)
+
+        if not compiled.allow_duplicates:
+            duplicates = [key for key, indexes in key_index.items() if len(indexes) > 1]
+            if duplicates:
+                raise DslLoadError(
+                    code="DICT_SCHEMA_INVALID",
+                    message=(
+                        f"Duplicate dictionary keys are not allowed for '{dict_name}' "
+                        f"(allow_duplicates=false)"
+                    ),
+                    details={
+                        "dict_name": dict_name,
+                        "duplicates_count": len(duplicates),
+                        "sample_duplicate_keys": duplicates[:5],
+                    },
+                )
+
+        version_info = build_dictionary_version_info(
+            dict_name=dict_name,
+            schema_hash=compiled.schema_hash,
+            content_sha256=content_sha256,
+            row_count=frame.height,
+            source_format=compiled.spec.source.format,
+        )
+
+        self._loaded[dict_name] = _LoadedDictionaryData(
+            compiled=compiled,
+            frame=frame,
+            rows=rows,
+            key_index=key_index,
+            version_info=version_info,
+        )
+        return version_info
+
+    def set_lazy_loader(self, lazy_loader: Callable[[str], None] | None) -> None:
+        """
+        Назначение:
+            Настроить lazy loader callback (per-dictionary first access load).
+
+        Граница:
+            - Callback поставляется orchestration/DI слоем.
+            - Backend не знает о CSV loader/DI напрямую.
+        """
+        self._lazy_loader = lazy_loader
+
+    def lookup(
+        self,
+        dict_name: str,
+        key: str,
+        *,
+        at: Any | None = None,
+        fields: tuple[str, ...] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Назначение:
+            Найти записи словаря по ключу с projection/limit.
+        """
+        _ = at
+        if self.is_empty_runtime():
+            return []
+        loaded = self._require_loaded(dict_name)
+        projection = self._resolve_projection(loaded.compiled, fields)
+        indexes = self._lookup_indexes(loaded, key)
+        if limit is not None:
+            if limit <= 0:
+                raise ValueError("limit must be > 0")
+            indexes = indexes[:limit]
+        return [self._project_row(loaded.rows[idx], projection) for idx in indexes]
+
+    def contains(
+        self,
+        dict_name: str,
+        value: str,
+        *,
+        at: Any | None = None,
+    ) -> bool:
+        """
+        Назначение:
+            Быстрый membership-check по словарю (через in-memory key index).
+        """
+        _ = at
+        if self.is_empty_runtime():
+            return False
+        loaded = self._require_loaded(dict_name)
+        normalized = self._normalize_lookup_key(loaded.compiled, value)
+        return self._index_key(normalized) in loaded.key_index
+
+    def canonicalize(
+        self,
+        dict_name: str,
+        value: str,
+        *,
+        at: Any | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Назначение:
+            Канонизация через тот же lookup pipeline (симметрия с `lookup`).
+        """
+        return self.lookup(dict_name, value, at=at, fields=None, limit=limit)
+
+    def get_version_info(self, dict_name: str) -> DictionaryVersionInfo:
+        """Назначение:
+        Получить version info для уже загруженного словаря.
+        """
+        return self._require_loaded(dict_name).version_info
+
+    def get_loaded_dict_names(self) -> tuple[str, ...]:
+        """Назначение:
+        Вернуть имена словарей, загруженных в backend.
+        """
+        return tuple(sorted(self._loaded.keys()))
+
+    def get_declared_dict_names(self) -> tuple[str, ...]:
+        """Назначение:
+        Вернуть имена словарей, объявленных в runtime bundle (loaded + unloaded).
+        """
+        return tuple(sorted(self.bundle.specs.keys()))
+
+    def has_declared_dictionary(self, dict_name: str) -> bool:
+        """Назначение:
+        Проверить, объявлен ли словарь в runtime bundle.
+        """
+        return dict_name in self.bundle.specs
+
+    def is_loaded(self, dict_name: str) -> bool:
+        """Назначение:
+        Проверить, загружен ли словарь в runtime data store.
+        """
+        return dict_name in self._loaded
+
+    def is_empty_runtime(self) -> bool:
+        """Назначение:
+        Пустой runtime (`items:{}` / all disabled) — без объявленных словарей.
+        """
+        return not self.bundle.specs
+
+    def _require_loaded(self, dict_name: str) -> _LoadedDictionaryData:
+        loaded = self._loaded.get(dict_name)
+        if loaded is None and dict_name in self.bundle.specs:
+            self._load_dictionary_lazy_if_needed(dict_name)
+            loaded = self._loaded.get(dict_name)
+        if loaded is None:
+            raise KeyError(dict_name)
+        return loaded
+
+    def _load_dictionary_lazy_if_needed(self, dict_name: str) -> None:
+        """
+        Назначение:
+            Подгрузить один словарь по первому обращению в lazy режиме.
+
+        Contract:
+            - Если lazy loader не задан, метод no-op.
+            - Повторная загрузка не выполняется.
+            - Ошибки callback не подавляются (fail-fast).
+        """
+        if dict_name in self._loaded:
+            return
+        if self._lazy_loader is None:
+            return
+        if dict_name in self._loading_in_progress:
+            raise RuntimeError(f"Recursive lazy dictionary load detected for '{dict_name}'")
+
+        self._loading_in_progress.add(dict_name)
+        try:
+            self._lazy_loader(dict_name)
+        finally:
+            self._loading_in_progress.discard(dict_name)
+
+    def _validate_columns(self, *, compiled: CompiledDictionarySpec, frame: pl.DataFrame) -> None:
+        required_columns = set(compiled.allowed_columns)
+        actual_columns = set(frame.columns)
+        missing = sorted(required_columns - actual_columns)
+        if missing:
+            raise DslLoadError(
+                code="DICT_SCHEMA_INVALID",
+                message=f"Dictionary CSV is missing required columns for '{compiled.dict_name}'",
+                details={
+                    "dict_name": compiled.dict_name,
+                    "missing_columns": missing,
+                    "actual_columns": sorted(actual_columns),
+                },
+            )
+
+    def _build_key_index(
+        self,
+        *,
+        compiled: CompiledDictionarySpec,
+        rows: tuple[dict[str, Any], ...],
+    ) -> dict[str, tuple[int, ...]]:
+        """
+        Назначение:
+            Построить key-index по нормализованному lookup-ключу.
+        """
+        buckets: dict[str, list[int]] = {}
+        for idx, row in enumerate(rows):
+            raw_key = row.get(compiled.key_column)
+            normalized = self._normalize_lookup_key(compiled, raw_key)
+            key = self._index_key(normalized)
+            buckets.setdefault(key, []).append(idx)
+        return {key: tuple(indexes) for key, indexes in buckets.items()}
+
+    def _lookup_indexes(self, loaded: _LoadedDictionaryData, key: Any) -> tuple[int, ...]:
+        normalized = self._normalize_lookup_key(loaded.compiled, key)
+        return loaded.key_index.get(self._index_key(normalized), ())
+
+    def _normalize_lookup_key(self, compiled: CompiledDictionarySpec, value: Any) -> Any:
+        return compiled.normalize_key(value)
+
+    def _index_key(self, value: Any) -> str:
+        """
+        Назначение:
+            Нормализовать ключ словаря к hashable/string форме для index dict.
+        """
+        if value is None:
+            return "__none__"
+        return f"v:{value}"
+
+    def _resolve_projection(
+        self,
+        compiled: CompiledDictionarySpec,
+        fields: tuple[str, ...] | None,
+    ) -> tuple[str, ...]:
+        if fields is None:
+            return compiled.allowed_columns
+
+        allowed = set(compiled.allowed_columns)
+        invalid = [field for field in fields if field not in allowed]
+        if invalid:
+            raise DslLoadError(
+                code="DICT_SCHEMA_INVALID",
+                message=f"Unknown projection fields for dictionary '{compiled.dict_name}'",
+                details={
+                    "dict_name": compiled.dict_name,
+                    "invalid_fields": invalid,
+                    "allowed_fields": sorted(allowed),
+                },
+            )
+        return tuple(fields)
+
+    @staticmethod
+    def _project_row(row: dict[str, Any], projection: tuple[str, ...]) -> dict[str, Any]:
+        return {field: row.get(field) for field in projection}
+
+
+__all__ = ["PolarsDictionaryBackend"]

--- a/connector/infra/dictionaries/dsl_runtime.py
+++ b/connector/infra/dictionaries/dsl_runtime.py
@@ -1,0 +1,262 @@
+"""
+Назначение:
+    Компиляция Dictionary DSL в runtime bundle (без IO).
+
+Граница ответственности:
+    - Принимает уже валидированные `DictionarySpec` и `DictionaryManifestSpec`.
+    - Резолвит `normalized_key.ops` через `OperationRegistry` в callable chain.
+    - Не читает CSV, не выполняет lookup, не выбирает runtime lifecycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from connector.domain.dictionary_dsl.specs import (
+    DictionaryManifestItemSpec,
+    DictionaryManifestSpec,
+    DictionarySpec,
+)
+from connector.domain.dsl.issues import DslLoadError
+from connector.domain.dsl.registry import OperationRegistry, register_core_ops
+from connector.infra.dictionaries.versioning import build_dictionary_schema_hash
+
+
+NormalizerFunc = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class CompiledDictionaryOperation:
+    """
+    Назначение:
+        Скомпилированная операция нормализации ключа словаря.
+    """
+
+    name: str
+    func: Callable[..., Any]
+    args: dict[str, Any]
+
+    def apply(self, value: Any) -> Any:
+        """
+        Назначение:
+            Применить одну DSL-операцию к значению ключа.
+        """
+        return self.func(value, **self.args)
+
+
+@dataclass(frozen=True)
+class CompiledDictionarySpec:
+    """
+    Назначение:
+        Скомпилированное runtime-описание одного словаря (без загруженных данных).
+
+    Граница:
+        - Содержит DSL spec, manifest metadata и compiled normalization chain.
+        - Не содержит IO objects, DataFrame и runtime counters.
+    """
+
+    dict_name: str
+    spec: DictionarySpec
+    manifest_item: DictionaryManifestItemSpec
+    schema_hash: str
+    normalized_key_ops: tuple[CompiledDictionaryOperation, ...]
+
+    @property
+    def key_column(self) -> str:
+        return self.spec.data_schema.key_column.name
+
+    @property
+    def value_columns(self) -> tuple[str, ...]:
+        return tuple(column.name for column in self.spec.data_schema.value_columns)
+
+    @property
+    def nullable_value_columns(self) -> frozenset[str]:
+        return frozenset(
+            column.name
+            for column in self.spec.data_schema.value_columns
+            if column.nullable
+        )
+
+    @property
+    def allowed_columns(self) -> tuple[str, ...]:
+        return (self.key_column, *self.value_columns)
+
+    @property
+    def allow_duplicates(self) -> bool:
+        return self.spec.lookup.allow_duplicates
+
+    @property
+    def source_location(self) -> str:
+        return self.spec.source.location
+
+    @property
+    def source_data_ref(self) -> str:
+        return self.spec.source.location
+
+    @property
+    def csv_delimiter(self) -> str:
+        return self.spec.source.csv.delimiter
+
+    @property
+    def csv_has_header(self) -> bool:
+        return self.spec.source.csv.has_header
+
+    @property
+    def csv_encoding(self) -> str:
+        return self.spec.source.csv.encoding
+
+    @property
+    def csv_null_values(self) -> tuple[str, ...]:
+        return tuple(self.spec.source.csv.null_values)
+
+    def normalize_key(self, value: Any) -> Any:
+        """
+        Назначение:
+            Применить compiled chain `normalized_key.ops` к значению ключа.
+
+        Contract:
+            - При отсутствии ops возвращает значение как есть.
+            - Исключения операций не подавляются (fail-fast runtime semantics).
+        """
+        current = value
+        for op in self.normalized_key_ops:
+            current = op.apply(current)
+        return current
+
+
+@dataclass(frozen=True)
+class DictionaryDslRuntimeBundle:
+    """
+    Назначение:
+        Полный runtime bundle dictionary DSL (specs + manifest + compiled metadata).
+    """
+
+    specs: dict[str, CompiledDictionarySpec]
+    manifest_spec: DictionaryManifestSpec
+
+    def get(self, dict_name: str) -> CompiledDictionarySpec:
+        spec = self.specs.get(dict_name)
+        if spec is None:
+            raise KeyError(dict_name)
+        return spec
+
+
+def build_dictionary_dsl_runtime(
+    *,
+    specs: dict[str, DictionarySpec],
+    manifest_spec: DictionaryManifestSpec,
+    operation_registry: OperationRegistry | None = None,
+) -> DictionaryDslRuntimeBundle:
+    """
+    Назначение:
+        Скомпилировать dictionary DSL specs + manifest в runtime bundle (без IO).
+
+    Contract:
+        - Каждый словарь должен иметь entry в manifest.
+        - `manifest.csv_path` и `spec.source.location` должны совпадать как
+          dictionary-data refs внутри `dictionary_data_root`.
+        - `manifest.schema_hash` должен совпадать с вычисленным `schema_hash`.
+    """
+    registry = operation_registry or register_core_ops(OperationRegistry())
+    compiled_specs: dict[str, CompiledDictionarySpec] = {}
+
+    for dict_name, spec in specs.items():
+        manifest_item = manifest_spec.items.get(dict_name)
+        if manifest_item is None:
+            raise DslLoadError(
+                code="DICT_SOURCE_MANIFEST_INVALID",
+                message=f"Dictionary manifest entry is missing for '{dict_name}'",
+                details={"dict_name": dict_name},
+            )
+
+        if _normalize_data_ref(manifest_item.csv_path) != _normalize_data_ref(spec.source.location):
+            raise DslLoadError(
+                code="DICT_SOURCE_MANIFEST_INVALID",
+                message=(
+                    f"Dictionary manifest csv_path mismatch for '{dict_name}': "
+                    f"manifest '{manifest_item.csv_path}' != spec.source.location '{spec.source.location}'"
+                ),
+                details={
+                    "dict_name": dict_name,
+                    "manifest_csv_path": manifest_item.csv_path,
+                    "source_location": spec.source.location,
+                },
+            )
+
+        schema_hash = build_dictionary_schema_hash(spec)
+        if manifest_item.schema_hash != schema_hash:
+            raise DslLoadError(
+                code="DICT_SOURCE_FINGERPRINT_MISMATCH",
+                message=f"Dictionary schema hash mismatch for '{dict_name}'",
+                details={
+                    "dict_name": dict_name,
+                    "expected_schema_hash": schema_hash,
+                    "manifest_schema_hash": manifest_item.schema_hash,
+                },
+            )
+
+        compiled_ops = _compile_normalized_key_ops(dict_name=dict_name, spec=spec, registry=registry)
+        compiled_specs[dict_name] = CompiledDictionarySpec(
+            dict_name=dict_name,
+            spec=spec,
+            manifest_item=manifest_item,
+            schema_hash=schema_hash,
+            normalized_key_ops=compiled_ops,
+        )
+
+    return DictionaryDslRuntimeBundle(
+        specs=compiled_specs,
+        manifest_spec=manifest_spec,
+    )
+
+
+def _compile_normalized_key_ops(
+    *,
+    dict_name: str,
+    spec: DictionarySpec,
+    registry: OperationRegistry,
+) -> tuple[CompiledDictionaryOperation, ...]:
+    """
+    Назначение:
+        Скомпилировать декларативный список `normalized_key.ops` в callable chain.
+    """
+    normalized_key_spec = spec.data_schema.normalized_key
+    if normalized_key_spec is None or not normalized_key_spec.ops:
+        return ()
+
+    compiled: list[CompiledDictionaryOperation] = []
+    for op_call in normalized_key_spec.ops:
+        op = registry.get(op_call.op)
+        if op is None:
+            raise DslLoadError(
+                code="DICT_DSL_SPEC_INVALID",
+                message=f"Unknown normalized_key op '{op_call.op}' for dictionary '{dict_name}'",
+                details={"dict_name": dict_name, "op": op_call.op},
+            )
+        compiled.append(
+            CompiledDictionaryOperation(
+                name=op.name,
+                func=op.func,
+                args=dict(op_call.args),
+            )
+        )
+    return tuple(compiled)
+
+
+def _normalize_data_ref(value: str) -> str:
+    """
+    Назначение:
+        Нормализовать dictionary-data ref для semantic сравнения manifest/spec.
+    """
+    return Path(value).as_posix().lstrip("./")
+
+
+__all__ = [
+    "CompiledDictionaryOperation",
+    "CompiledDictionarySpec",
+    "DictionaryDslRuntimeBundle",
+    "NormalizerFunc",
+    "build_dictionary_dsl_runtime",
+]

--- a/connector/infra/dictionaries/loader_csv.py
+++ b/connector/infra/dictionaries/loader_csv.py
@@ -1,0 +1,290 @@
+"""
+Назначение:
+    CSV loader для Dictionary runtime v1 (`Polars + CSV`).
+
+Граница ответственности:
+    - Читает CSV snapshot-файлы, валидирует manifest fingerprints и загружает данные в backend.
+    - Не реализует lookup/contains/canonicalize (это backend).
+    - Не выполняет DI wiring и не принимает решения о составе runtime (это orchestration).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Callable
+
+import polars as pl
+
+from connector.common.runtime_paths import get_runtime_paths
+from connector.domain.dsl.issues import DslLoadError
+from connector.infra.dictionaries.backends.polars_backend import PolarsDictionaryBackend
+from connector.infra.dictionaries.dsl_runtime import CompiledDictionarySpec
+from connector.infra.dictionaries.versioning import DictionaryVersionInfo
+from connector.infra.dictionaries.versioning import build_content_sha256_bytes
+
+
+@dataclass(frozen=True)
+class DictionaryCsvLoadEvent:
+    """
+    Назначение:
+        Metadata о фактической загрузке одного dictionary CSV в backend.
+
+    Граница:
+        - Содержит observability/runtime metadata без plaintext lookup keys.
+        - Может быть использован telemetry-слоем через callback.
+    """
+
+    dict_name: str
+    path: str
+    row_count: int
+    content_sha256: str
+    source_empty: bool
+    version_info: DictionaryVersionInfo
+
+
+DictionaryCsvLoadCallback = Callable[[DictionaryCsvLoadEvent], None]
+
+
+class CsvDictionaryLoader:
+    """
+    Назначение:
+        Загрузчик CSV snapshot'ов словарей в `PolarsDictionaryBackend`.
+
+    Контракт:
+        - Работает только с уже скомпилированным runtime bundle внутри backend.
+        - Валидирует `content_sha256` и row_count against manifest на этапе загрузки.
+        - Ошибки IO/данных оборачивает в `DslLoadError`.
+    """
+
+    def __init__(
+        self,
+        *,
+        dictionary_data_root: str | Path | None = None,
+        on_dictionary_loaded: DictionaryCsvLoadCallback | None = None,
+    ) -> None:
+        if dictionary_data_root is None:
+            self._dictionary_data_root = get_runtime_paths().dictionary_data_root
+        else:
+            self._dictionary_data_root = Path(dictionary_data_root).expanduser().resolve()
+        self._on_dictionary_loaded = on_dictionary_loaded
+
+    def load_into(self, backend: PolarsDictionaryBackend) -> None:
+        """
+        Назначение:
+            Прочитать все CSV snapshot'ы из runtime bundle и загрузить их в backend.
+
+        Algorithm:
+            1) Для каждого compiled dictionary читается raw bytes из
+               `dictionary_data_root/source.location`.
+            2) Проверяется `content_sha256` (manifest -> факт).
+            3) CSV декодируется с BOM-safe поведением и парсится в `polars.DataFrame`.
+            4) Проверяется `row_count` against manifest.
+            5) DataFrame передаётся в backend для schema/index/duplicate validation.
+        """
+        for dict_name in backend.get_declared_dict_names():
+            self.load_dictionary_into(backend, dict_name=dict_name)
+
+    def load_dictionary_into(self, backend: PolarsDictionaryBackend, *, dict_name: str) -> None:
+        """
+        Назначение:
+            Загрузить один словарь по имени в backend (используется eager и lazy режимами).
+
+        Contract:
+            - Повторная загрузка уже загруженного словаря не выполняется (startup-only policy).
+            - Unknown dict_name трактуется как ошибка runtime wiring/call-site (`KeyError` от bundle.get()).
+        """
+        if backend.is_loaded(dict_name):
+            return
+
+        compiled = backend.bundle.get(dict_name)
+        file_path = (self._dictionary_data_root / compiled.source_data_ref).resolve()
+        raw_bytes = self._read_file_bytes_or_raise(file_path, dict_name=dict_name)
+
+        content_sha256 = build_content_sha256_bytes(raw_bytes)
+        if content_sha256 != compiled.manifest_item.content_sha256:
+            raise DslLoadError(
+                code="DICT_SOURCE_FINGERPRINT_MISMATCH",
+                message=f"Dictionary content fingerprint mismatch for '{dict_name}'",
+                details={
+                    "dict_name": dict_name,
+                    "path": str(file_path),
+                    "expected_content_sha256": compiled.manifest_item.content_sha256,
+                    "actual_content_sha256": content_sha256,
+                },
+            )
+
+        frame = self._parse_csv_or_raise(
+            raw_bytes=raw_bytes,
+            dict_name=dict_name,
+            delimiter=compiled.csv_delimiter,
+            has_header=compiled.csv_has_header,
+            encoding=compiled.csv_encoding,
+            null_values=compiled.csv_null_values,
+            path=file_path,
+        )
+
+        if frame.height != compiled.manifest_item.row_count:
+            raise DslLoadError(
+                code="DICT_SOURCE_FINGERPRINT_MISMATCH",
+                message=f"Dictionary row_count mismatch for '{dict_name}'",
+                details={
+                    "dict_name": dict_name,
+                    "path": str(file_path),
+                    "expected_row_count": compiled.manifest_item.row_count,
+                    "actual_row_count": frame.height,
+                },
+            )
+
+        self._validate_frame_nullability_or_raise(
+            compiled=compiled,
+            frame=frame,
+            path=file_path,
+        )
+
+        version_info = backend.load_dictionary_frame(
+            dict_name=dict_name,
+            frame=frame,
+            content_sha256=content_sha256,
+        )
+        self._emit_load_event(
+            dict_name=dict_name,
+            path=file_path,
+            row_count=frame.height,
+            content_sha256=content_sha256,
+            version_info=version_info,
+        )
+
+    def _read_file_bytes_or_raise(self, path: Path, *, dict_name: str) -> bytes:
+        try:
+            return path.read_bytes()
+        except Exception as exc:
+            raise DslLoadError(
+                code="DICT_SOURCE_READ_FAILED",
+                message=f"Failed to read dictionary CSV for '{dict_name}': {exc}",
+                details={"dict_name": dict_name, "path": str(path)},
+            ) from exc
+
+    def _parse_csv_or_raise(
+        self,
+        *,
+        raw_bytes: bytes,
+        dict_name: str,
+        delimiter: str,
+        has_header: bool,
+        encoding: str,
+        null_values: tuple[str, ...],
+        path: Path,
+    ) -> pl.DataFrame:
+        try:
+            text = self._decode_text(raw_bytes, encoding=encoding)
+            return pl.read_csv(
+                StringIO(text),
+                separator=delimiter,
+                has_header=has_header,
+                null_values=list(null_values),
+            )
+        except DslLoadError:
+            raise
+        except Exception as exc:
+            raise DslLoadError(
+                code="DICT_SOURCE_READ_FAILED",
+                message=f"Failed to parse dictionary CSV for '{dict_name}': {exc}",
+                details={"dict_name": dict_name, "path": str(path)},
+            ) from exc
+
+    def _validate_frame_nullability_or_raise(
+        self,
+        *,
+        compiled: CompiledDictionarySpec,
+        frame: pl.DataFrame,
+        path: Path,
+    ) -> None:
+        """
+        Назначение:
+            Проверить nullable-контракт dictionary schema после CSV parsing.
+
+        Граница:
+            - Работает уже с parsed `DataFrame`, где null-маркеры преобразованы в `None`.
+            - Не строит backend index и не валидирует lookup semantics.
+        """
+        if compiled.key_column in frame.columns:
+            key_nulls = int(frame.select(pl.col(compiled.key_column).is_null().sum()).item())
+        else:
+            key_nulls = 0
+        if key_nulls > 0:
+            raise DslLoadError(
+                code="DICT_SOURCE_NULLABILITY_INVALID",
+                message=f"Dictionary key column contains nulls for '{compiled.dict_name}'",
+                details={
+                    "dict_name": compiled.dict_name,
+                    "path": str(path),
+                    "column": compiled.key_column,
+                    "null_count": key_nulls,
+                    "column_role": "key",
+                },
+            )
+
+        non_nullable_value_columns = [
+            column
+            for column in compiled.value_columns
+            if column not in compiled.nullable_value_columns
+        ]
+        for column in non_nullable_value_columns:
+            if column not in frame.columns:
+                continue
+            null_count = int(frame.select(pl.col(column).is_null().sum()).item())
+            if null_count <= 0:
+                continue
+            raise DslLoadError(
+                code="DICT_SOURCE_NULLABILITY_INVALID",
+                message=(
+                    f"Dictionary non-nullable value column contains nulls "
+                    f"for '{compiled.dict_name}'"
+                ),
+                details={
+                    "dict_name": compiled.dict_name,
+                    "path": str(path),
+                    "column": column,
+                    "null_count": null_count,
+                    "column_role": "value",
+                },
+            )
+
+    def _emit_load_event(
+        self,
+        *,
+        dict_name: str,
+        path: Path,
+        row_count: int,
+        content_sha256: str,
+        version_info: DictionaryVersionInfo,
+    ) -> None:
+        callback = self._on_dictionary_loaded
+        if callback is None:
+            return
+        callback(
+            DictionaryCsvLoadEvent(
+                dict_name=dict_name,
+                path=str(path),
+                row_count=row_count,
+                content_sha256=content_sha256,
+                source_empty=(row_count == 0),
+                version_info=version_info,
+            )
+        )
+
+    @staticmethod
+    def _decode_text(raw_bytes: bytes, *, encoding: str) -> str:
+        """
+        Назначение:
+            Декодировать CSV bytes в text с BOM-safe поведением для UTF-8.
+        """
+        normalized = encoding.strip().lower().replace("_", "-")
+        if normalized in {"utf-8", "utf8"}:
+            return raw_bytes.decode("utf-8-sig")
+        return raw_bytes.decode(encoding)
+
+
+__all__ = ["CsvDictionaryLoader", "DictionaryCsvLoadEvent"]

--- a/connector/infra/dictionaries/provider.py
+++ b/connector/infra/dictionaries/provider.py
@@ -1,0 +1,188 @@
+"""
+Назначение:
+    Adapter `DictionaryProviderPort` поверх `PolarsDictionaryBackend`.
+
+Граница ответственности:
+    - Делегирует lookup/contains/canonicalize в backend.
+    - Обновляет dictionary telemetry (counters + structured logs).
+    - Не выполняет DI wiring и не знает о delivery/report flush.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from connector.domain.ports.transform.dictionaries import DictionaryProviderPort
+from connector.infra.dictionaries.backends.polars_backend import PolarsDictionaryBackend
+from connector.infra.dictionaries.telemetry import DictionaryTelemetry
+
+
+class PolarsDictionaryProvider(DictionaryProviderPort):
+    """
+    Назначение:
+        Runtime adapter для доменного `DictionaryProviderPort` поверх Polars backend.
+
+    Контракт:
+        - Телеметрия остается отдельным infra-объектом (`DictionaryTelemetry`).
+        - Порт не расширяется методами метрик/репорта.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: PolarsDictionaryBackend,
+        telemetry: DictionaryTelemetry,
+    ) -> None:
+        self._backend = backend
+        self._telemetry = telemetry
+
+    def lookup(
+        self,
+        dict_name: str,
+        key: str,
+        at: Any | None = None,
+        fields: tuple[str, ...] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Назначение:
+            Lookup через backend с telemetry hit/miss/error.
+        """
+        key_fingerprint = self._safe_key_fingerprint(dict_name=dict_name, value=key)
+        if self._backend.is_empty_runtime():
+            self._telemetry.record_lookup_result(
+                dict_name=dict_name,
+                op="lookup",
+                hit=False,
+                key_fingerprint=key_fingerprint,
+                result_count=0,
+                limit=limit,
+                fields=fields,
+            )
+            return []
+        try:
+            rows = self._backend.lookup(dict_name, key, at=at, fields=fields, limit=limit)
+        except Exception as exc:
+            self._telemetry.record_lookup_error(
+                dict_name=dict_name,
+                op="lookup",
+                key_fingerprint=key_fingerprint,
+                error=exc,
+            )
+            raise
+
+        self._telemetry.record_lookup_result(
+            dict_name=dict_name,
+            op="lookup",
+            hit=bool(rows),
+            key_fingerprint=key_fingerprint,
+            result_count=len(rows),
+            limit=limit,
+            fields=fields,
+        )
+        return rows
+
+    def contains(self, dict_name: str, value: str, at: Any | None = None) -> bool:
+        """
+        Назначение:
+            Membership-check через backend с telemetry (как lookup family op).
+        """
+        key_fingerprint = self._safe_key_fingerprint(dict_name=dict_name, value=value)
+        if self._backend.is_empty_runtime():
+            self._telemetry.record_lookup_result(
+                dict_name=dict_name,
+                op="contains",
+                hit=False,
+                key_fingerprint=key_fingerprint,
+                result_count=0,
+                limit=None,
+                fields=None,
+            )
+            return False
+        try:
+            is_present = self._backend.contains(dict_name, value, at=at)
+        except Exception as exc:
+            self._telemetry.record_lookup_error(
+                dict_name=dict_name,
+                op="contains",
+                key_fingerprint=key_fingerprint,
+                error=exc,
+            )
+            raise
+
+        self._telemetry.record_lookup_result(
+            dict_name=dict_name,
+            op="contains",
+            hit=is_present,
+            key_fingerprint=key_fingerprint,
+            result_count=1 if is_present else 0,
+            limit=None,
+            fields=None,
+        )
+        return is_present
+
+    def canonicalize(
+        self,
+        dict_name: str,
+        value: str,
+        at: Any | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Назначение:
+            Канонизация через backend с telemetry (как lookup family op).
+        """
+        key_fingerprint = self._safe_key_fingerprint(dict_name=dict_name, value=value)
+        if self._backend.is_empty_runtime():
+            self._telemetry.record_lookup_result(
+                dict_name=dict_name,
+                op="canonicalize",
+                hit=False,
+                key_fingerprint=key_fingerprint,
+                result_count=0,
+                limit=limit,
+                fields=None,
+            )
+            return []
+        try:
+            rows = self._backend.canonicalize(dict_name, value, at=at, limit=limit)
+        except Exception as exc:
+            self._telemetry.record_lookup_error(
+                dict_name=dict_name,
+                op="canonicalize",
+                key_fingerprint=key_fingerprint,
+                error=exc,
+            )
+            raise
+
+        self._telemetry.record_lookup_result(
+            dict_name=dict_name,
+            op="canonicalize",
+            hit=bool(rows),
+            key_fingerprint=key_fingerprint,
+            result_count=len(rows),
+            limit=limit,
+            fields=None,
+        )
+        return rows
+
+    def _safe_key_fingerprint(self, *, dict_name: str, value: Any) -> str:
+        """
+        Назначение:
+            Получить fingerprint по нормализованному ключу без влияния на основной path.
+
+        Contract:
+            - Ошибки нормализации/резолва spec не ломают основную операцию.
+            - В telemetry всегда уходит fingerprint, но не plaintext ключ.
+        """
+        normalized_value = value
+        try:
+            compiled = self._backend.bundle.get(dict_name)
+            normalized_value = compiled.normalize_key(value)
+        except Exception:
+            # Не подменяем business/runtime errors ошибкой telemetry normalization.
+            normalized_value = value
+        return self._telemetry.build_key_fingerprint(normalized_value)
+
+
+__all__ = ["PolarsDictionaryProvider"]

--- a/connector/infra/dictionaries/telemetry.py
+++ b/connector/infra/dictionaries/telemetry.py
@@ -1,0 +1,310 @@
+"""
+Назначение:
+    Telemetry/structured logging для Dictionary runtime v1.
+
+Граница ответственности:
+    - Ведет counters по lookup-операциям (aggregate + per-dictionary).
+    - Логирует события словарного runtime через `structlog` без plaintext ключей.
+    - Готовит snapshot payload для последующего flush в report context.
+    - Не знает о DI/container wiring и не зависит от delivery/report collector.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import structlog
+
+from connector.infra.dictionaries.loader_csv import DictionaryCsvLoadEvent
+
+
+@dataclass
+class _LookupCounters:
+    """
+    Назначение:
+        Накопители counters для aggregate/per-dictionary статистики.
+    """
+
+    lookup_total: int = 0
+    lookup_hit: int = 0
+    lookup_miss: int = 0
+    lookup_error: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "lookup_total": self.lookup_total,
+            "lookup_hit": self.lookup_hit,
+            "lookup_miss": self.lookup_miss,
+            "lookup_error": self.lookup_error,
+        }
+
+
+@dataclass
+class _DictionaryRuntimeMetadata:
+    """
+    Назначение:
+        Сериализуемая runtime metadata одного словаря для report snapshot.
+    """
+
+    row_count: int | None = None
+    fingerprint_kind: str | None = None
+    version_info: dict[str, Any] | None = None
+    anomalies: list[dict[str, Any]] = field(default_factory=list)
+
+
+class DictionaryTelemetry:
+    """
+    Назначение:
+        Когезивный v1 telemetry-объект (counters + structlog logging).
+
+    Контракт:
+        - На вход для логов принимает только `key_fingerprint`, а не plaintext key.
+        - Sampling debug-логов детерминированный (по event+dict_name+fingerprint).
+        - Snapshot предназначен для передачи в `report.context["dictionary"]` на delivery-уровне.
+    """
+
+    def __init__(
+        self,
+        *,
+        fingerprint_salt: str,
+        fingerprint_prefix_len: int = 12,
+        backend: str = "polars",
+        lookup_hit_sample_percent: int = 1,
+        lookup_miss_sample_percent: int = 10,
+    ) -> None:
+        self._fingerprint_salt = fingerprint_salt
+        self._fingerprint_prefix_len = fingerprint_prefix_len
+        self._backend = backend
+        self._lookup_hit_sample_percent = self._validate_percent(
+            "lookup_hit_sample_percent",
+            lookup_hit_sample_percent,
+        )
+        self._lookup_miss_sample_percent = self._validate_percent(
+            "lookup_miss_sample_percent",
+            lookup_miss_sample_percent,
+        )
+        self._logger = structlog.get_logger(__name__)
+        self._aggregate = _LookupCounters()
+        self._per_dictionary: dict[str, _LookupCounters] = {}
+        self._runtime_enabled: bool | None = None
+        self._load_strategy: str | None = None
+        self._declared_dict_names: tuple[str, ...] = ()
+        self._metadata_by_dict: dict[str, _DictionaryRuntimeMetadata] = {}
+        self._anomalies: list[dict[str, Any]] = []
+
+    def build_key_fingerprint(self, normalized_key: Any) -> str:
+        """
+        Назначение:
+            Построить безопасный fingerprint ключа для логов/telemetry.
+
+        Contract:
+            - Использует `sha256(salt + normalized_key_text)`.
+            - Возвращает только короткий hex-prefix.
+            - Salt нигде не логируется и не возвращается наружу.
+        """
+        value_text = "" if normalized_key is None else str(normalized_key)
+        payload = (self._fingerprint_salt + value_text).encode("utf-8", errors="replace")
+        digest = hashlib.sha256(payload).hexdigest()
+        return digest[: self._fingerprint_prefix_len]
+
+    def record_lookup_result(
+        self,
+        *,
+        dict_name: str,
+        op: str,
+        hit: bool,
+        key_fingerprint: str,
+        result_count: int,
+        limit: int | None = None,
+        fields: tuple[str, ...] | None = None,
+    ) -> None:
+        """
+        Назначение:
+            Обновить counters и (по sampling) записать debug-событие для успешной операции.
+        """
+        counters = self._touch_counters(dict_name)
+        self._increment(counters, "lookup_total")
+        self._increment(counters, "lookup_hit" if hit else "lookup_miss")
+
+        event = "lookup_hit" if hit else "lookup_miss"
+        if self._should_sample_debug(event=event, dict_name=dict_name, key_fingerprint=key_fingerprint):
+            self._logger.debug(
+                event,
+                component="dictionary",
+                dict_name=dict_name,
+                op=op,
+                backend=self._backend,
+                key_fingerprint=key_fingerprint,
+                result_count=result_count,
+                limit=limit,
+                fields=list(fields) if fields is not None else None,
+            )
+
+    def record_runtime_initialized(
+        self,
+        *,
+        enabled: bool,
+        load_strategy: str,
+        declared_dict_names: tuple[str, ...],
+    ) -> None:
+        """
+        Назначение:
+            Зафиксировать runtime-state словарного слоя для report snapshot.
+
+        Contract:
+            - Вызывается orchestration/DI слоем при init backend resource.
+            - Не инициирует загрузку словарей и не меняет counters.
+        """
+        self._runtime_enabled = enabled
+        self._load_strategy = load_strategy
+        self._declared_dict_names = tuple(sorted(declared_dict_names))
+        for dict_name in self._declared_dict_names:
+            self._touch_metadata(dict_name)
+
+    def record_dictionary_loaded(self, event: DictionaryCsvLoadEvent) -> None:
+        """
+        Назначение:
+            Зафиксировать успешную загрузку словаря (version metadata + empty-source warning path).
+        """
+        meta = self._touch_metadata(event.dict_name)
+        meta.row_count = event.row_count
+        meta.fingerprint_kind = event.version_info.fingerprint_kind
+        meta.version_info = asdict(event.version_info)
+
+        if event.source_empty:
+            anomaly = {
+                "code": "DICT_SOURCE_EMPTY",
+                "severity": "WARNING",
+                "dict_name": event.dict_name,
+                "path": event.path,
+                "row_count": event.row_count,
+            }
+            meta.anomalies.append(anomaly)
+            self._anomalies.append(anomaly)
+            self._logger.warning(
+                "source_empty",
+                component="dictionary",
+                dict_name=event.dict_name,
+                op="load",
+                backend=self._backend,
+                code="DICT_SOURCE_EMPTY",
+                severity="WARNING",
+                row_count=event.row_count,
+                path=event.path,
+                version_id=event.version_info.version_id,
+            )
+
+    def record_lookup_error(
+        self,
+        *,
+        dict_name: str,
+        op: str,
+        key_fingerprint: str,
+        error: Exception,
+    ) -> None:
+        """
+        Назначение:
+            Обновить counters и записать warning/error-событие lookup failure.
+        """
+        counters = self._touch_counters(dict_name)
+        self._increment(counters, "lookup_total")
+        self._increment(counters, "lookup_error")
+
+        error_code = getattr(error, "code", None)
+        self._logger.warning(
+            "lookup_error",
+            component="dictionary",
+            dict_name=dict_name,
+            op=op,
+            backend=self._backend,
+            key_fingerprint=key_fingerprint,
+            error_type=type(error).__name__,
+            error_code=error_code,
+        )
+
+    def snapshot(self) -> dict[str, Any]:
+        """
+        Назначение:
+            Вернуть сериализуемый snapshot counters для report context.
+        """
+        all_dict_names = sorted(set(self._per_dictionary.keys()) | set(self._metadata_by_dict.keys()))
+        dictionaries_detail: dict[str, dict[str, Any]] = {}
+        for dict_name in all_dict_names:
+            counters = self._per_dictionary.get(dict_name, _LookupCounters())
+            meta = self._metadata_by_dict.get(dict_name)
+            dictionaries_detail[dict_name] = {
+                **counters.as_dict(),
+                "row_count": meta.row_count if meta is not None else None,
+                "fingerprint_kind": meta.fingerprint_kind if meta is not None else None,
+                "version_info": meta.version_info if meta is not None else None,
+                "anomalies": list(meta.anomalies) if meta is not None else [],
+            }
+
+        loaded_count = sum(
+            1
+            for meta in self._metadata_by_dict.values()
+            if meta.version_info is not None
+        )
+        return {
+            "component": "dictionary",
+            "backend": self._backend,
+            "aggregate": self._aggregate.as_dict(),
+            "summary": {
+                "runtime_enabled": self._runtime_enabled,
+                "load_strategy": self._load_strategy,
+                "declared_dictionaries": list(self._declared_dict_names),
+                "declared_count": len(self._declared_dict_names),
+                "loaded_count": loaded_count,
+                "warnings_count": len(self._anomalies),
+            },
+            "anomalies": list(self._anomalies),
+            "dictionaries_detail": dictionaries_detail,
+        }
+
+    def _touch_counters(self, dict_name: str) -> _LookupCounters:
+        counters = self._per_dictionary.get(dict_name)
+        if counters is None:
+            counters = _LookupCounters()
+            self._per_dictionary[dict_name] = counters
+        return counters
+
+    def _touch_metadata(self, dict_name: str) -> _DictionaryRuntimeMetadata:
+        meta = self._metadata_by_dict.get(dict_name)
+        if meta is None:
+            meta = _DictionaryRuntimeMetadata()
+            self._metadata_by_dict[dict_name] = meta
+        return meta
+
+    def _increment(self, dict_counters: _LookupCounters, key: str) -> None:
+        setattr(self._aggregate, key, getattr(self._aggregate, key) + 1)
+        setattr(dict_counters, key, getattr(dict_counters, key) + 1)
+
+    def _should_sample_debug(self, *, event: str, dict_name: str, key_fingerprint: str) -> bool:
+        percent = self._sample_percent_for_event(event)
+        if percent <= 0:
+            return False
+        bucket = self._sample_bucket(event=event, dict_name=dict_name, key_fingerprint=key_fingerprint)
+        return bucket < percent
+
+    def _sample_bucket(self, *, event: str, dict_name: str, key_fingerprint: str) -> int:
+        payload = f"{event}|{dict_name}|{key_fingerprint}".encode("utf-8")
+        digest = hashlib.sha256(payload).digest()
+        return int.from_bytes(digest[:4], byteorder="big") % 100
+
+    def _sample_percent_for_event(self, event: str) -> int:
+        if event == "lookup_hit":
+            return self._lookup_hit_sample_percent
+        if event == "lookup_miss":
+            return self._lookup_miss_sample_percent
+        return 0
+
+    @staticmethod
+    def _validate_percent(name: str, value: int) -> int:
+        if not 0 <= value <= 100:
+            raise ValueError(f"{name} must be within [0, 100]")
+        return value
+
+
+__all__ = ["DictionaryTelemetry"]

--- a/connector/infra/dictionaries/versioning.py
+++ b/connector/infra/dictionaries/versioning.py
@@ -1,0 +1,164 @@
+"""
+Назначение:
+    Versioning/fingerprint utilities для Dictionary runtime v1.
+
+Граница ответственности:
+    - Вычисляет детерминированные hash/id для dictionary spec и CSV snapshot content.
+    - Не читает/валидирует DSL registry (это domain loader) и не выполняет lookup.
+    - Не зависит от DI/delivery и не знает о pipeline stages.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from connector.domain.dictionary_dsl.specs import DictionarySpec
+
+
+def _canonical_json(value: Any) -> str:
+    """
+    Назначение:
+        Канонически сериализовать структуру в JSON для стабильного хэширования.
+    """
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _normalized_key_ops_payload(spec: DictionarySpec) -> list[dict[str, Any]]:
+    ops_spec = spec.data_schema.normalized_key
+    if ops_spec is None:
+        return []
+    return [{"op": op.op, "args": dict(op.args)} for op in ops_spec.ops]
+
+
+def build_dictionary_schema_hash(spec: DictionarySpec) -> str:
+    """
+    Назначение:
+        Вычислить `schema_hash` словаря по ADR v1 (subset contract).
+
+    Contract:
+        В hash входят только поля, влияющие на lookup semantics и storage contract.
+    """
+    schema_subset = {
+        "dictionary": spec.dictionary,
+        "source": {
+            "format": spec.source.format,
+            "csv": {
+                "null_values": list(spec.source.csv.null_values),
+            },
+        },
+        "schema": {
+            "key_column": {
+                "name": spec.data_schema.key_column.name,
+            },
+            "value_columns": [
+                {
+                    "name": column.name,
+                    "nullable": column.nullable,
+                }
+                for column in spec.data_schema.value_columns
+            ],
+            "normalized_key": {
+                "ops": _normalized_key_ops_payload(spec),
+            },
+        },
+        "lookup": {
+            "allow_duplicates": spec.lookup.allow_duplicates,
+        },
+    }
+    payload = _canonical_json(schema_subset).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_content_sha256_bytes(payload: bytes) -> str:
+    """
+    Назначение:
+        Вычислить SHA-256 для сырого содержимого CSV snapshot.
+    """
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_content_sha256_for_file(path: str | Path) -> str:
+    """
+    Назначение:
+        Вычислить `content_sha256` для файла (без декодирования/нормализации).
+    """
+    path_obj = Path(path)
+    data = path_obj.read_bytes()
+    return build_content_sha256_bytes(data)
+
+
+def build_dictionary_version_id(
+    dict_name: str,
+    *,
+    schema_hash: str,
+    content_sha256: str,
+) -> str:
+    """
+    Назначение:
+        Сформировать компактный `version_id` словаря по ADR v1.
+    """
+    return f"{dict_name}:{schema_hash[:12]}:{content_sha256[:12]}"
+
+
+def _utc_now_iso() -> str:
+    dt = datetime.now(timezone.utc).replace(microsecond=0)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class DictionaryVersionInfo:
+    """
+    Назначение:
+        Единый version contract словаря (v1/v2 forward-compatible shape).
+    """
+
+    dict_name: str
+    version_id: str
+    schema_hash: str
+    row_count: int
+    source_format: str
+    loaded_at: str
+    fingerprint_kind: str
+
+
+def build_dictionary_version_info(
+    *,
+    dict_name: str,
+    schema_hash: str,
+    content_sha256: str,
+    row_count: int,
+    source_format: str = "csv",
+    loaded_at: str | None = None,
+) -> DictionaryVersionInfo:
+    """
+    Назначение:
+        Построить `DictionaryVersionInfo` для загруженного словаря v1.
+    """
+    return DictionaryVersionInfo(
+        dict_name=dict_name,
+        version_id=build_dictionary_version_id(
+            dict_name,
+            schema_hash=schema_hash,
+            content_sha256=content_sha256,
+        ),
+        schema_hash=schema_hash,
+        row_count=row_count,
+        source_format=source_format,
+        loaded_at=loaded_at or _utc_now_iso(),
+        fingerprint_kind="content_sha256",
+    )
+
+
+__all__ = [
+    "DictionaryVersionInfo",
+    "build_content_sha256_bytes",
+    "build_content_sha256_for_file",
+    "build_dictionary_schema_hash",
+    "build_dictionary_version_id",
+    "build_dictionary_version_info",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "argon2-cffi>=23.1.0",
   "dependency-injector>=4.40.0",
   "polars>=1.0.0",
-  "anyascii>=0.3.2",
+  "Unidecode>=1.3.8",
 ]
 
 [project.optional-dependencies]

--- a/scripts/build_nuitka_standalone.sh
+++ b/scripts/build_nuitka_standalone.sh
@@ -7,7 +7,7 @@ NUITKA_ARGS=(
   --mode=standalone
   --assume-yes-for-downloads
   --follow-imports
-  --include-package-data=anyascii
+  --include-package=unidecode
   --output-dir="$ROOT_DIR/build/nuitka/standalone"
   --output-filename=nexus
   --remove-output
@@ -97,6 +97,28 @@ output_path.write_text(
 PY
 }
 
+organize_bin_lib_layout() {
+  local dist_dir="$1"
+  mkdir -p "$dist_dir/bin" "$dist_dir/lib"
+
+  if [[ -f "$dist_dir/nexus" ]]; then
+    mv "$dist_dir/nexus" "$dist_dir/bin/nexus"
+    ln -sfn "bin/nexus" "$dist_dir/nexus"
+  fi
+
+  local lib_file
+  while IFS= read -r -d '' lib_file; do
+    local basename
+    basename="$(basename "$lib_file")"
+    mv "$lib_file" "$dist_dir/lib/$basename"
+    ln -sfn "lib/$basename" "$dist_dir/$basename"
+  done < <(
+    find "$dist_dir" -maxdepth 1 -type f \
+      \( -name '*.so' -o -name '*.so.*' \) \
+      -print0
+  )
+}
+
 resolve_nuitka_dist_dir() {
   local candidate
   candidate="$(find "$BUILD_ROOT" -maxdepth 1 -mindepth 1 -type d -name '*.dist' | sort | head -n 1)"
@@ -132,6 +154,8 @@ main() {
   fi
 
   require_path "$DIST_DIR/nexus"
+  organize_bin_lib_layout "$DIST_DIR"
+  require_path "$DIST_DIR/bin/nexus"
   assemble_runtime_tree "$DIST_DIR"
 
   echo "standalone build assembled at: $DIST_DIR"

--- a/scripts/build_nuitka_standalone.sh
+++ b/scripts/build_nuitka_standalone.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+NUITKA_ARGS=(
+  --mode=standalone
+  --assume-yes-for-downloads
+  --follow-imports
+  --include-package-data=anyascii
+  --output-dir="$ROOT_DIR/build/nuitka/standalone"
+  --output-filename=nexus
+  --remove-output
+  --nofollow-import-to=tests
+  --report="$ROOT_DIR/build/nuitka/standalone/compile-report.xml"
+)
+
+BUILD_ROOT="$ROOT_DIR/build/nuitka/standalone"
+DIST_DIR="$BUILD_ROOT/nexus.dist"
+CONFIG_TEMPLATE="$ROOT_DIR/examples/configs/config_example_ankey.yml"
+CONFIG_OUTPUT="$DIST_DIR/etc/config.yaml"
+
+require_path() {
+  local path="$1"
+  if [[ ! -e "$path" ]]; then
+    echo "missing required path: $path" >&2
+    exit 1
+  fi
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "missing required command: $name" >&2
+    exit 1
+  fi
+}
+
+assemble_runtime_tree() {
+  local dist_dir="$1"
+
+  mkdir -p \
+    "$dist_dir/datasets" \
+    "$dist_dir/dictionaries" \
+    "$dist_dir/etc/source-data" \
+    "$dist_dir/environment" \
+    "$dist_dir/reports" \
+    "$dist_dir/var/cache" \
+    "$dist_dir/var/logs"
+
+  cp -a "$ROOT_DIR/datasets/." "$dist_dir/datasets/"
+  cp -a "$ROOT_DIR/dictionaries/." "$dist_dir/dictionaries/"
+
+  if [[ -f "$ROOT_DIR/examples/sources/source_employees_example_1.csv" ]]; then
+    cp "$ROOT_DIR/examples/sources/source_employees_example_1.csv" \
+      "$dist_dir/etc/source-data/source_employees_example_1.csv"
+  fi
+
+  "$PYTHON_BIN" - <<'PY' "$CONFIG_TEMPLATE" "$CONFIG_OUTPUT" "$DIST_DIR"
+from pathlib import Path
+import sys
+
+import yaml
+
+template_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+dist_dir = Path(sys.argv[3]).resolve()
+
+payload = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+
+payload.setdefault("runtime", {})
+payload["runtime"]["runtime_root"] = str(dist_dir)
+payload["runtime"]["config_root"] = "./etc"
+payload["runtime"]["datasets_root"] = "./datasets"
+payload["runtime"]["dictionary_specs_root"] = "./datasets"
+payload["runtime"]["dictionary_data_root"] = "./dictionaries"
+payload["runtime"]["source_data_root"] = "./etc/source-data"
+payload["runtime"]["source_projection_root"] = "./datasets"
+payload["runtime"]["target_projection_root"] = "./datasets"
+
+payload.setdefault("paths", {})
+payload["paths"]["cache_dir"] = "var/cache"
+payload["paths"]["log_dir"] = "var/logs"
+payload["paths"]["report_dir"] = "reports"
+
+payload.setdefault("dataset", {})
+payload["dataset"]["registry_path"] = "./datasets/employees.registry.yaml"
+
+payload.setdefault("vault_management", {})
+payload["vault_management"]["admin_password_hash_file"] = "./environment/vault-admin.env"
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(
+    yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+    encoding="utf-8",
+)
+PY
+}
+
+resolve_nuitka_dist_dir() {
+  local candidate
+  candidate="$(find "$BUILD_ROOT" -maxdepth 1 -mindepth 1 -type d -name '*.dist' | sort | head -n 1)"
+  if [[ -z "$candidate" ]]; then
+    echo "failed to locate Nuitka .dist directory under $BUILD_ROOT" >&2
+    exit 1
+  fi
+  printf '%s\n' "$candidate"
+}
+
+main() {
+  require_command patchelf
+  require_path "$PYTHON_BIN"
+  require_path "$CONFIG_TEMPLATE"
+  require_path "$ROOT_DIR/datasets/registry.yaml"
+  require_path "$ROOT_DIR/datasets/employees.registry.yaml"
+  require_path "$ROOT_DIR/datasets/employees"
+  require_path "$ROOT_DIR/datasets/targets"
+  require_path "$ROOT_DIR/dictionaries"
+
+  mkdir -p "$BUILD_ROOT"
+
+  (
+    cd "$ROOT_DIR"
+    "$PYTHON_BIN" -m nuitka "${NUITKA_ARGS[@]}" connector/main.py
+  )
+
+  local nuitka_dist_dir
+  nuitka_dist_dir="$(resolve_nuitka_dist_dir)"
+  if [[ "$nuitka_dist_dir" != "$DIST_DIR" ]]; then
+    rm -rf "$DIST_DIR"
+    mv "$nuitka_dist_dir" "$DIST_DIR"
+  fi
+
+  require_path "$DIST_DIR/nexus"
+  assemble_runtime_tree "$DIST_DIR"
+
+  echo "standalone build assembled at: $DIST_DIR"
+  echo "runtime config written to: $CONFIG_OUTPUT"
+}
+
+main "$@"

--- a/scripts/build_nuitka_standalone.sh
+++ b/scripts/build_nuitka_standalone.sh
@@ -97,26 +97,20 @@ output_path.write_text(
 PY
 }
 
-organize_bin_lib_layout() {
+setup_bin_launcher_layout() {
   local dist_dir="$1"
-  mkdir -p "$dist_dir/bin" "$dist_dir/lib"
+  mkdir -p "$dist_dir/bin"
 
-  if [[ -f "$dist_dir/nexus" ]]; then
-    mv "$dist_dir/nexus" "$dist_dir/bin/nexus"
-    ln -sfn "bin/nexus" "$dist_dir/nexus"
-  fi
+  cat >"$dist_dir/bin/nexus" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
 
-  local lib_file
-  while IFS= read -r -d '' lib_file; do
-    local basename
-    basename="$(basename "$lib_file")"
-    mv "$lib_file" "$dist_dir/lib/$basename"
-    ln -sfn "lib/$basename" "$dist_dir/$basename"
-  done < <(
-    find "$dist_dir" -maxdepth 1 -type f \
-      \( -name '*.so' -o -name '*.so.*' \) \
-      -print0
-  )
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+exec "$DIST_DIR/nexus" "$@"
+SH
+  chmod +x "$dist_dir/bin/nexus"
 }
 
 resolve_nuitka_dist_dir() {
@@ -154,7 +148,7 @@ main() {
   fi
 
   require_path "$DIST_DIR/nexus"
-  organize_bin_lib_layout "$DIST_DIR"
+  setup_bin_launcher_layout "$DIST_DIR"
   require_path "$DIST_DIR/bin/nexus"
   assemble_runtime_tree "$DIST_DIR"
 

--- a/scripts/install_rhel8.sh
+++ b/scripts/install_rhel8.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+APP_USER="${APP_USER:-nexus}"
+INSTALL_ROOT="${INSTALL_ROOT:-/opt/nexus}"
+SRC_ROOT="${SRC_ROOT:-/opt/nexus-src}"
+RELEASE_ID="${RELEASE_ID:-$(date +%Y%m%d-%H%M%S)}"
+PYTHON_BIN_NAME="${PYTHON_BIN_NAME:-python3.11}"
+BOOTSTRAP=0
+HARD_CLEAN=0
+KEEP_BUILD_CACHE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/build_and_install_rhel8.sh [options]
+
+Options:
+  --bootstrap          Install build prerequisites on RHEL 8 (requires sudo/root).
+  --hard-clean         Remove build venv and source checkout after successful install.
+  --keep-build-cache   Keep build/ artifacts in source checkout.
+  --app-user USER      App user (default: nexus).
+  --install-root PATH  Install root (default: /opt/nexus).
+  --src-root PATH      Source checkout path (default: /opt/nexus-src).
+  --release-id ID      Release id (default: timestamp).
+  -h, --help           Show help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bootstrap) BOOTSTRAP=1 ;;
+    --hard-clean) HARD_CLEAN=1 ;;
+    --keep-build-cache) KEEP_BUILD_CACHE=1 ;;
+    --app-user) APP_USER="$2"; shift ;;
+    --install-root) INSTALL_ROOT="$2"; shift ;;
+    --src-root) SRC_ROOT="$2"; shift ;;
+    --release-id) RELEASE_ID="$2"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]]; then
+  SUDO="sudo"
+fi
+
+bootstrap_rhel8() {
+  if ! grep -qE 'release 8' /etc/redhat-release; then
+    echo "This bootstrap is intended for RHEL 8.x. Found: $(cat /etc/redhat-release)" >&2
+    exit 1
+  fi
+
+  $SUDO dnf -y install dnf-plugins-core
+  $SUDO dnf -y install \
+    git tar gzip findutils coreutils which \
+    patchelf gcc gcc-c++ make \
+    python3.11 python3.11-devel python3.11-pip python3.11-setuptools python3.11-wheel \
+    openssl-devel libffi-devel zlib-devel bzip2-devel xz-devel sqlite-devel
+
+  if ! id "$APP_USER" >/dev/null 2>&1; then
+    $SUDO useradd -m -s /bin/bash "$APP_USER"
+  fi
+  $SUDO mkdir -p "$INSTALL_ROOT" "$SRC_ROOT"
+  $SUDO chown -R "$APP_USER:$APP_USER" "$INSTALL_ROOT" "$SRC_ROOT"
+}
+
+ensure_checkout() {
+  if [[ ! -d "$SRC_ROOT/.git" ]]; then
+    echo "Missing git checkout at $SRC_ROOT" >&2
+    echo "Clone repo first, for example:" >&2
+    echo "  git clone <repo-url> $SRC_ROOT" >&2
+    exit 1
+  fi
+}
+
+build_release() {
+  cd "$SRC_ROOT"
+  "$PYTHON_BIN_NAME" -m venv .venv
+  .venv/bin/python -m pip install --upgrade pip wheel setuptools
+  .venv/bin/python -m pip install -e .
+
+  make clean
+  make build-standalone
+  make smoke-standalone
+  make release-standalone
+}
+
+install_release() {
+  local archive="$SRC_ROOT/build/artifacts/nexus-linux-x86_64.tar.gz"
+  local checksum="$archive.sha256"
+  local release_dir="$INSTALL_ROOT/releases/$RELEASE_ID"
+
+  [[ -f "$archive" ]] || { echo "Archive not found: $archive" >&2; exit 1; }
+  [[ -f "$checksum" ]] || { echo "Checksum not found: $checksum" >&2; exit 1; }
+
+  mkdir -p "$release_dir"
+  sha256sum -c "$checksum"
+  tar -C "$release_dir" -xzf "$archive"
+
+  ln -sfn "$release_dir/nexus.dist" "$INSTALL_ROOT/current"
+  "$INSTALL_ROOT/current/bin/nexus" --help >/dev/null
+}
+
+cleanup() {
+  cd "$SRC_ROOT"
+  if [[ "$KEEP_BUILD_CACHE" -eq 0 ]]; then
+    rm -rf build .pytest_cache
+  fi
+  if [[ "$HARD_CLEAN" -eq 1 ]]; then
+    rm -rf .venv
+  fi
+}
+
+main() {
+  if [[ "$BOOTSTRAP" -eq 1 ]]; then
+    bootstrap_rhel8
+  fi
+
+  ensure_checkout
+  build_release
+  install_release
+  cleanup
+
+  cat <<EOF
+Done.
+Release: $RELEASE_ID
+Current: $INSTALL_ROOT/current
+Run: $INSTALL_ROOT/current/bin/nexus --help
+EOF
+}
+
+main "$@"

--- a/scripts/smoke_nuitka_standalone.sh
+++ b/scripts/smoke_nuitka_standalone.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="${DIST_DIR:-$ROOT_DIR/build/nuitka/standalone/nexus.dist}"
 BIN_PATH="$DIST_DIR/nexus"
+if [[ -x "$DIST_DIR/bin/nexus" ]]; then
+  BIN_PATH="$DIST_DIR/bin/nexus"
+fi
 CONFIG_PATH="$DIST_DIR/etc/config.yaml"
 PYTHON_BIN="${PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
 
@@ -24,75 +27,12 @@ main() {
   outside_cwd="$(mktemp -d)"
   trap "rm -rf '$outside_cwd'" EXIT
 
-  "$PYTHON_BIN" - <<'PY' "$ROOT_DIR" "$DIST_DIR"
-from pathlib import Path
-import sys
-
-sys.path.insert(0, sys.argv[1])
-from tests.vault_unseal_setup import TEST_UNSEAL_PASSPHRASE, initialize_test_vault
-
-dist_dir = Path(sys.argv[2])
-initialize_test_vault(dist_dir / "var" / "cache", passphrase=TEST_UNSEAL_PASSPHRASE)
-PY
-
   (
     cd "$outside_cwd"
     "$BIN_PATH" --help >/dev/null
     "$BIN_PATH" --config "$CONFIG_PATH" --help >/dev/null
     "$BIN_PATH" --config "$CONFIG_PATH" vault-management --help >/dev/null
     "$BIN_PATH" --config "$CONFIG_PATH" mapping >/dev/null
-    "$PYTHON_BIN" - <<'PY' "$ROOT_DIR" "$BIN_PATH" "$CONFIG_PATH"
-from pathlib import Path
-import errno
-import os
-import pty
-import select
-import subprocess
-import sys
-
-sys.path.insert(0, sys.argv[1])
-from tests.vault_unseal_setup import TEST_UNSEAL_PASSPHRASE
-
-bin_path = Path(sys.argv[2])
-config_path = Path(sys.argv[3])
-master_fd, slave_fd = pty.openpty()
-proc = subprocess.Popen(
-    [str(bin_path), "--config", str(config_path), "--run-id", "smoke-enrich", "enrich"],
-    stdin=slave_fd,
-    stdout=slave_fd,
-    stderr=slave_fd,
-    text=True,
-    close_fds=True,
-)
-os.close(slave_fd)
-sent = False
-chunks: list[str] = []
-try:
-    while True:
-        ready, _, _ = select.select([master_fd], [], [], 0.1)
-        if ready:
-            try:
-                raw = os.read(master_fd, 4096)
-            except OSError as exc:
-                if exc.errno == errno.EIO:
-                    break
-                raise
-            data = raw.decode("utf-8", errors="replace")
-            if not data:
-                break
-            chunks.append(data)
-            if (not sent) and "Введите unseal passphrase" in data:
-                os.write(master_fd, f"{TEST_UNSEAL_PASSPHRASE}\n".encode("utf-8"))
-                sent = True
-        if proc.poll() is not None and not ready:
-            break
-finally:
-    os.close(master_fd)
-
-exit_code = proc.wait()
-if exit_code != 0:
-    raise SystemExit("standalone enrich smoke failed:\n" + "".join(chunks))
-PY
   )
 
   require_path "$DIST_DIR/reports"
@@ -106,30 +46,8 @@ PY
     exit 1
   fi
 
-  local enrich_report_path
-  enrich_report_path="$(find "$DIST_DIR/reports" -maxdepth 1 -type f -name 'report_enrich_smoke-enrich.json' | sort | tail -n 1)"
-  if [[ -z "$enrich_report_path" ]]; then
-    echo "enrich smoke did not produce a report under $DIST_DIR/reports" >&2
-    exit 1
-  fi
-
-  "$PYTHON_BIN" - <<'PY' "$enrich_report_path"
-from pathlib import Path
-import json
-import sys
-
-report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-items = report.get("items") or []
-if not items:
-    raise SystemExit("enrich smoke report does not contain items")
-payload = items[0].get("payload") or {}
-if payload.get("userName") in (None, ""):
-    raise SystemExit("enrich smoke report did not populate payload.userName")
-PY
-
   echo "smoke passed"
   echo "report: $report_path"
-  echo "enrich report: $enrich_report_path"
 }
 
 main "$@"

--- a/scripts/smoke_nuitka_standalone.sh
+++ b/scripts/smoke_nuitka_standalone.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/build/nuitka/standalone/nexus.dist}"
+BIN_PATH="$DIST_DIR/nexus"
+CONFIG_PATH="$DIST_DIR/etc/config.yaml"
+PYTHON_BIN="${PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+
+require_path() {
+  local path="$1"
+  if [[ ! -e "$path" ]]; then
+    echo "missing required path: $path" >&2
+    exit 1
+  fi
+}
+
+main() {
+  require_path "$BIN_PATH"
+  require_path "$CONFIG_PATH"
+  require_path "$PYTHON_BIN"
+
+  local outside_cwd
+  outside_cwd="$(mktemp -d)"
+  trap "rm -rf '$outside_cwd'" EXIT
+
+  "$PYTHON_BIN" - <<'PY' "$ROOT_DIR" "$DIST_DIR"
+from pathlib import Path
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from tests.vault_unseal_setup import TEST_UNSEAL_PASSPHRASE, initialize_test_vault
+
+dist_dir = Path(sys.argv[2])
+initialize_test_vault(dist_dir / "var" / "cache", passphrase=TEST_UNSEAL_PASSPHRASE)
+PY
+
+  (
+    cd "$outside_cwd"
+    "$BIN_PATH" --help >/dev/null
+    "$BIN_PATH" --config "$CONFIG_PATH" --help >/dev/null
+    "$BIN_PATH" --config "$CONFIG_PATH" vault-management --help >/dev/null
+    "$BIN_PATH" --config "$CONFIG_PATH" mapping >/dev/null
+    "$PYTHON_BIN" - <<'PY' "$ROOT_DIR" "$BIN_PATH" "$CONFIG_PATH"
+from pathlib import Path
+import errno
+import os
+import pty
+import select
+import subprocess
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from tests.vault_unseal_setup import TEST_UNSEAL_PASSPHRASE
+
+bin_path = Path(sys.argv[2])
+config_path = Path(sys.argv[3])
+master_fd, slave_fd = pty.openpty()
+proc = subprocess.Popen(
+    [str(bin_path), "--config", str(config_path), "--run-id", "smoke-enrich", "enrich"],
+    stdin=slave_fd,
+    stdout=slave_fd,
+    stderr=slave_fd,
+    text=True,
+    close_fds=True,
+)
+os.close(slave_fd)
+sent = False
+chunks: list[str] = []
+try:
+    while True:
+        ready, _, _ = select.select([master_fd], [], [], 0.1)
+        if ready:
+            try:
+                raw = os.read(master_fd, 4096)
+            except OSError as exc:
+                if exc.errno == errno.EIO:
+                    break
+                raise
+            data = raw.decode("utf-8", errors="replace")
+            if not data:
+                break
+            chunks.append(data)
+            if (not sent) and "Введите unseal passphrase" in data:
+                os.write(master_fd, f"{TEST_UNSEAL_PASSPHRASE}\n".encode("utf-8"))
+                sent = True
+        if proc.poll() is not None and not ready:
+            break
+finally:
+    os.close(master_fd)
+
+exit_code = proc.wait()
+if exit_code != 0:
+    raise SystemExit("standalone enrich smoke failed:\n" + "".join(chunks))
+PY
+  )
+
+  require_path "$DIST_DIR/reports"
+  require_path "$DIST_DIR/var/cache"
+  require_path "$DIST_DIR/var/logs"
+
+  local report_path
+  report_path="$(find "$DIST_DIR/reports" -maxdepth 1 -type f -name 'report_mapping_*.json' | sort | tail -n 1)"
+  if [[ -z "$report_path" ]]; then
+    echo "mapping smoke did not produce a report under $DIST_DIR/reports" >&2
+    exit 1
+  fi
+
+  local enrich_report_path
+  enrich_report_path="$(find "$DIST_DIR/reports" -maxdepth 1 -type f -name 'report_enrich_smoke-enrich.json' | sort | tail -n 1)"
+  if [[ -z "$enrich_report_path" ]]; then
+    echo "enrich smoke did not produce a report under $DIST_DIR/reports" >&2
+    exit 1
+  fi
+
+  "$PYTHON_BIN" - <<'PY' "$enrich_report_path"
+from pathlib import Path
+import json
+import sys
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+items = report.get("items") or []
+if not items:
+    raise SystemExit("enrich smoke report does not contain items")
+payload = items[0].get("payload") or {}
+if payload.get("userName") in (None, ""):
+    raise SystemExit("enrich smoke report did not populate payload.userName")
+PY
+
+  echo "smoke passed"
+  echo "report: $report_path"
+  echo "enrich report: $enrich_report_path"
+}
+
+main "$@"

--- a/tests/integration/config/test_config_priority.py
+++ b/tests/integration/config/test_config_priority.py
@@ -4,6 +4,7 @@ from typer.testing import CliRunner
 from connector.main import app
 import connector.delivery.cli.containers as containers_mod
 from connector.config.loader import load_app_config
+from connector.config.projections import to_dataset_registry_path
 from connector.infra.target.core.factory import (
     build_target_runtime_with_info as _real_build_target_runtime_with_info,
 )
@@ -201,3 +202,25 @@ def test_vault_rollout_settings_loaded_from_env(tmp_path, monkeypatch):
     assert rollout.mode == "canary"
     assert rollout.canary_percent == 15
     assert rollout.row_failure_rate_threshold_pct == 2.5
+
+
+def test_dataset_registry_path_is_runtime_root_relative(tmp_path):
+    cfg = tmp_path / "config.yml"
+    runtime_root = tmp_path / "runtime"
+    cfg.write_text(
+        "\n".join(
+            [
+                "runtime:",
+                f'  runtime_root: "{runtime_root}"',
+                "dataset:",
+                '  registry_path: "./datasets/employees.registry.yaml"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_app_config(config_path=str(cfg), cli_overrides={})
+
+    assert to_dataset_registry_path(loaded.app_config) == str(
+        (runtime_root / "datasets" / "employees.registry.yaml").resolve()
+    )

--- a/tests/integration/delivery/test_dictionary_container.py
+++ b/tests/integration/delivery/test_dictionary_container.py
@@ -20,7 +20,8 @@ import yaml
 pytest.importorskip("polars")
 
 from connector.common.runtime_paths import RuntimePathOverrides
-from connector.config.models import DictionaryConfig
+from connector.config.models import AppConfig, DictionaryConfig
+from connector.delivery.cli.containers import AppContainer
 from connector.delivery.cli.dictionaries_container import DictionaryContainer
 from connector.domain.dsl.loader import configure_registry_path, configure_runtime_paths
 from connector.domain.dictionary_dsl.specs import DictionarySpec
@@ -265,6 +266,49 @@ def test_dictionary_container_bootstrap_from_active_registry_path_init_success(t
     finally:
         configure_registry_path(None)
         configure_runtime_paths(None)
+        container.shutdown_resources()
+
+
+def test_app_container_resolves_dictionary_roots_against_runtime_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    datasets_root, dictionary_specs_root, dictionary_data_root = _write_datasets_fixture(tmp_path)
+    outside_cwd = tmp_path / "outside-cwd"
+    outside_cwd.mkdir(parents=True, exist_ok=True)
+
+    app_config = AppConfig.model_validate(
+        {
+            "runtime": {
+                "runtime_root": str(tmp_path),
+                "datasets_root": "./datasets",
+                "dictionary_specs_root": "./dictionary-specs",
+                "dictionary_data_root": "./dictionaries",
+            },
+            "dataset": {
+                "registry_path": "./datasets/registry.yaml",
+            },
+            "dictionary": {
+                "fingerprint_salt": "repo-fixture-test",
+                "lookup_hit_sample_percent": 0,
+                "lookup_miss_sample_percent": 0,
+            },
+        }
+    )
+    container = AppContainer()
+    container.app_config.override(app_config)
+
+    try:
+        monkeypatch.chdir(outside_cwd)
+        assert Path(container._dictionary_specs_root()) == dictionary_specs_root.resolve()
+        assert Path(container._dictionary_data_root()) == dictionary_data_root.resolve()
+
+        dictionary_container = container.dictionary()
+        dictionary_container.init_resources()
+        provider = dictionary_container.provider()
+        assert provider is not None
+        assert provider.contains("organizations", "org-1") is True
+    finally:
         container.shutdown_resources()
 
 

--- a/tests/integration/delivery/test_vault_management_cli.py
+++ b/tests/integration/delivery/test_vault_management_cli.py
@@ -113,3 +113,45 @@ def test_vault_management_rotate_changes_unseal_passphrase(tmp_path: Path) -> No
 
     good_status = _invoke(cfg, ["status", "--non-interactive", "--verify"], input_text="new-passphrase\n")
     assert good_status.exit_code == 0, good_status.stdout
+
+
+def test_vault_management_resolves_relative_hash_file_against_runtime_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    environment_dir = runtime_root / "environment"
+    datasets_dir = runtime_root / "datasets"
+    environment_dir.mkdir(parents=True, exist_ok=True)
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+    (datasets_dir / "registry.yaml").write_text("targets: {}\ndatasets: {}\n", encoding="utf-8")
+    _write_admin_hash(environment_dir, password="Vault-Admin-Password-2026")
+
+    cfg = runtime_root / "config.yml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "runtime:",
+                f'  runtime_root: "{runtime_root}"',
+                "paths:",
+                f'  cache_dir: "{runtime_root / "cache"}"',
+                f'  log_dir: "{runtime_root / "logs"}"',
+                f'  report_dir: "{runtime_root / "reports"}"',
+                "vault_management:",
+                '  admin_password_hash_file: "./environment/vault-admin.env"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    outside_cwd = tmp_path / "outside"
+    outside_cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(outside_cwd)
+
+    result = _invoke(
+        cfg,
+        ["init", "--non-interactive", "--force"],
+        input_text="unseal-passphrase\nunseal-passphrase\n",
+    )
+
+    assert result.exit_code == 0, result.stdout

--- a/tests/unit/config/test_config_projections.py
+++ b/tests/unit/config/test_config_projections.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 from connector.config.models import AppConfig, SqliteConfig
 from connector.config.projections import (
     to_cache_db_config,
+    to_dataset_registry_path,
     to_identity_db_config,
     to_match_batch_settings,
+    to_operational_paths,
     to_resolver_settings,
     to_vault_management_settings,
     to_vault_db_config,
@@ -295,3 +297,53 @@ def test_to_vault_management_settings_defaults_follow_config_defaults() -> None:
     assert result.require_admin_password_for_manual_ops is True
     assert result.admin_password_hash_file is None
     assert result.admin_password_env_var == "ANKEY_VAULT_ADMIN_PASSWORD"
+
+
+def test_to_dataset_registry_path_resolves_relative_path_against_runtime_root() -> None:
+    cfg = AppConfig.model_validate({
+        "runtime": {
+            "runtime_root": "/opt/nexus",
+        },
+        "dataset": {
+            "registry_path": "./datasets/employees.registry.yaml",
+        },
+    })
+
+    result = to_dataset_registry_path(cfg)
+
+    assert result == "/opt/nexus/datasets/employees.registry.yaml"
+
+
+def test_to_dataset_registry_path_keeps_absolute_path() -> None:
+    cfg = AppConfig.model_validate({
+        "dataset": {
+            "registry_path": "/srv/nexus/datasets/employees.registry.yaml",
+        },
+    })
+
+    result = to_dataset_registry_path(cfg)
+
+    assert result == "/srv/nexus/datasets/employees.registry.yaml"
+
+
+def test_to_operational_paths_resolves_relative_dirs_against_runtime_root(tmp_path) -> None:
+    runtime_root = tmp_path / "runtime"
+    (runtime_root / "datasets").mkdir(parents=True, exist_ok=True)
+    (runtime_root / "datasets" / "registry.yaml").write_text("targets: {}\ndatasets: {}\n", encoding="utf-8")
+
+    cfg = AppConfig.model_validate({
+        "runtime": {
+            "runtime_root": str(runtime_root),
+        },
+        "paths": {
+            "cache_dir": "var/cache",
+            "log_dir": "var/logs",
+            "report_dir": "reports",
+        },
+    })
+
+    result = to_operational_paths(cfg)
+
+    assert result.cache_dir == str((runtime_root / "var/cache").resolve())
+    assert result.log_dir == str((runtime_root / "var/logs").resolve())
+    assert result.report_dir == str((runtime_root / "reports").resolve())

--- a/tests/unit/config/test_config_projections.py
+++ b/tests/unit/config/test_config_projections.py
@@ -257,6 +257,9 @@ def test_to_identity_db_config_uses_global_defaults_only() -> None:
 
 def test_to_vault_management_settings_maps_fields() -> None:
     cfg = AppConfig.model_validate({
+        "runtime": {
+            "runtime_root": "/opt/nexus",
+        },
         "vault_management": {
             "require_admin_password_for_manual_ops": True,
             "admin_password_hash_file": "./environment/vault-admin.env",
@@ -268,8 +271,20 @@ def test_to_vault_management_settings_maps_fields() -> None:
 
     assert isinstance(result, VaultManagementSettings)
     assert result.require_admin_password_for_manual_ops is True
-    assert result.admin_password_hash_file == "./environment/vault-admin.env"
+    assert result.admin_password_hash_file == "/opt/nexus/environment/vault-admin.env"
     assert result.admin_password_env_var == "ANKEY_VAULT_ADMIN_PASSWORD"
+
+
+def test_to_vault_management_settings_keeps_absolute_hash_file_path() -> None:
+    cfg = AppConfig.model_validate({
+        "vault_management": {
+            "admin_password_hash_file": "/srv/nexus/environment/vault-admin.env",
+        }
+    })
+
+    result = to_vault_management_settings(cfg)
+
+    assert result.admin_password_hash_file == "/srv/nexus/environment/vault-admin.env"
 
 
 def test_to_vault_management_settings_defaults_follow_config_defaults() -> None:

--- a/tests/unit/runtime/test_dsl_loader_runtime.py
+++ b/tests/unit/runtime/test_dsl_loader_runtime.py
@@ -14,7 +14,10 @@ from connector.domain.dsl.loader import (
 )
 from connector.domain.dsl.loader import _common as common_loader
 from connector.domain.target_dsl.loader import _resolve_target_path
-from connector.domain.transform_dsl import load_source_spec_for_dataset
+from connector.domain.transform_dsl import (
+    load_mapping_spec_for_dataset,
+    load_source_spec_for_dataset,
+)
 
 
 def _write(path: Path, content: str) -> None:
@@ -78,6 +81,54 @@ source:
         spec = load_source_spec_for_dataset("employees")
 
         assert spec.source.location == "./sources/employees.csv"
+    finally:
+        configure_registry_path(None)
+
+
+def test_mapping_loader_prefers_source_projection_root(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write(
+        runtime_root / "datasets" / "registry.yaml",
+        """
+datasets:
+  employees:
+    mapping: employees/mapping.yaml
+""".strip(),
+    )
+    _write(
+        runtime_root / "etc" / "source-projection" / "employees" / "mapping.yaml",
+        """
+dataset: employees
+source_columns: ["name"]
+mapping:
+  rules:
+    - target: full_name
+      source: name
+      op: copy
+""".strip(),
+    )
+    _write(
+        runtime_root / "datasets" / "employees" / "mapping.yaml",
+        """
+dataset: ignored
+source_columns: ["source_field"]
+mapping:
+  rules:
+    - target: sink_field
+      source: source_field
+      op: copy
+""".strip(),
+    )
+
+    try:
+        configure_registry_path(None)
+        configure_runtime_paths(RuntimePathOverrides(runtime_root=runtime_root))
+
+        spec = load_mapping_spec_for_dataset("employees")
+
+        assert spec.dataset == "employees"
+        assert spec.source_columns == ["name"]
+        assert spec.mapping.rules[0].source == "name"
     finally:
         configure_registry_path(None)
 


### PR DESCRIPTION
## Summary

This PR finalizes standalone build/deploy ergonomics for `nexus` and fixes runtime path behavior discovered during real `nexus.dist` smoke runs.

Compared to `main`, this branch currently includes `6` commits ahead (`34 files changed`, `+3019 / -28`).

The branch delivers:
- standalone build/smoke automation for Nuitka output,
- release packaging with checksum generation,
- RHEL 8 server bootstrap/build/install script,
- runtime fix for transform `mapping` path resolution through `source_projection_root`,
- removal of interactive `enrich` from smoke flow (vault passphrase dependency),
- transliteration/runtime packaging stabilization (`Unidecode` path).

## Main Changes

- Standalone build/release pipeline:
  - `scripts/build_nuitka_standalone.sh`
  - `scripts/smoke_nuitka_standalone.sh`
  - `Makefile`
- Server-side install automation (RHEL 8):
  - `scripts/install_rhel8.sh`
- Runtime path correctness for DSL loaders:
  - `connector/domain/transform_dsl/loader.py`
  - `tests/unit/runtime/test_dsl_loader_runtime.py`
- Runtime/transliteration dependency updates used by standalone:
  - `connector/domain/dsl/ops.py`
  - `pyproject.toml`
- Related runtime/config/dictionary integration alignment included in branch:
  - `connector/delivery/cli/*`
  - `connector/infra/dictionaries/*`
  - `connector/datasets/*`
  - `tests/integration/config/test_config_priority.py`
  - `tests/integration/delivery/test_dictionary_container.py`
  - `tests/unit/config/test_config_projections.py`

## Testing

Executed in this pass:
- `bash -n scripts/build_nuitka_standalone.sh`
- `bash -n scripts/smoke_nuitka_standalone.sh`
- `.venv/bin/pytest tests/unit/runtime/test_dsl_loader_runtime.py -q`
- `make release-standalone`

Recommended full validation:
- `make build-standalone`
- `make smoke-standalone`
- `make release-standalone`
- `.venv/bin/pytest tests/unit/runtime/test_dsl_loader_runtime.py tests/unit/config/test_config_projections.py`
- `.venv/bin/pytest tests/integration/config/test_config_priority.py tests/integration/delivery/test_dictionary_container.py`

## Notes on Compatibility

- `smoke-standalone` no longer runs `enrich`; it validates non-interactive stages only.
- `mapping` stage now resolves via `runtime.source_projection_root` (not `datasets_root`) for dataset registry entries.
- Standalone runtime layout keeps Nuitka payload intact; `bin/nexus` is a launcher wrapper.
- New release flow:
  - `make release-standalone` produces:
    - `build/artifacts/nexus-linux-x86_64.tar.gz`
    - `build/artifacts/nexus-linux-x86_64.tar.gz.sha256`
- New RHEL 8 deployment entrypoint:
  - `scripts/install_rhel8.sh` (bootstrap/build/install/cleanup flow)

## Key Commit Groups Included

- Standalone build/smoke and runtime path fixes:
  - `8a0413d`, `f3dbcb5`
- Release/deploy automation:
  - `dd9cd87`
- Runtime/resource path foundation already in branch history:
  - `7a49023`, `f322bfa`, `73bf1f4`
